### PR TITLE
Fix charts for dataset v3.0

### DIFF
--- a/src/components/data-recharts.tsx
+++ b/src/components/data-recharts.tsx
@@ -19,6 +19,9 @@ type DataGraphProps = {
 
 import React, { useMemo } from "react";
 
+// Use the same delimiter as the data processing
+const SERIES_NAME_DELIMITER = " | ";
+
 export const DataRecharts = React.memo(
   ({ data, onChartsReady }: DataGraphProps) => {
     // Shared hoveredTime for all graphs
@@ -47,7 +50,6 @@ export const DataRecharts = React.memo(
   },
 );
 
-const NESTED_KEY_DELIMITER = ",";
 
 const SingleDataGraph = React.memo(
   ({
@@ -66,13 +68,13 @@ const SingleDataGraph = React.memo(
         // Special case: if this is a group value that is a primitive, assign to prefix.key
         if (typeof value === "number") {
           if (prefix) {
-            result[`${prefix}${NESTED_KEY_DELIMITER}${key}`] = value;
+            result[`${prefix}${SERIES_NAME_DELIMITER}${key}`] = value;
           } else {
             result[key] = value;
           }
         } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
           // If it's an object, recurse
-          Object.assign(result, flattenRow(value, prefix ? `${prefix}${NESTED_KEY_DELIMITER}${key}` : key));
+          Object.assign(result, flattenRow(value, prefix ? `${prefix}${SERIES_NAME_DELIMITER}${key}` : key));
         }
       }
       // Always keep timestamp at top level if present
@@ -99,7 +101,7 @@ const SingleDataGraph = React.memo(
     const groups: Record<string, string[]> = {};
     const singles: string[] = [];
     dataKeys.forEach((key) => {
-      const parts = key.split(NESTED_KEY_DELIMITER);
+      const parts = key.split(SERIES_NAME_DELIMITER);
       if (parts.length > 1) {
         const group = parts[0];
         if (!groups[group]) groups[group] = [];
@@ -148,7 +150,7 @@ const SingleDataGraph = React.memo(
       const groups: Record<string, string[]> = {};
       const singles: string[] = [];
       dataKeys.forEach((key) => {
-        const parts = key.split(NESTED_KEY_DELIMITER);
+        const parts = key.split(SERIES_NAME_DELIMITER);
         if (parts.length > 1) {
           const group = parts[0];
           if (!groups[group]) groups[group] = [];
@@ -305,7 +307,7 @@ const SingleDataGraph = React.memo(
               {/* Render lines for visible dataKeys only */}
               {dataKeys.map((key) => {
                 // Use group color for all keys in a group
-                const group = key.includes(NESTED_KEY_DELIMITER) ? key.split(NESTED_KEY_DELIMITER)[0] : key;
+                const group = key.includes(SERIES_NAME_DELIMITER) ? key.split(SERIES_NAME_DELIMITER)[0] : key;
                 const color = groupColorMap[group];
                 let strokeDasharray: string | undefined = undefined;
                 if (groups[group] && groups[group].length > 1) {


### PR DESCRIPTION
# Fix V3.0 Data Visualization

V3.0 datasets were displaying chart data with confusing array-indexed naming, e.g., `observation.state[0]`, `action[1]`, instead of the hierarchical structure used in V2.1 datasets (e.g., `action | shoulder_pan`, `observation.state | joint_pos`).

<p align="center">
<b>Before this PR</b>

<img width="1226" height="436" alt="Screenshot 2025-09-14 at 17 59 26" src="https://github.com/user-attachments/assets/c3285512-3254-4ac7-b841-788191cfab31" />
</p>

<p align="center">
<b>After this PR</b>

<img width="1220" height="406" alt="Screenshot 2025-09-14 at 17 59 18" src="https://github.com/user-attachments/assets/ec62cccd-ff03-4a4e-b431-04ef0e964fbd" />
</p>

**Solution**
Updated V3.0 data processing to use the same hierarchical naming convention and grouping logic as V2.1, ensuring consistent visualization experience across dataset versions.

### Changes Made

#### `fetch-data.ts`
- **Hierarchical Naming**: Modified V3.0 processing to use `SERIES_NAME_DELIMITER` (" | ") format instead of array indices
- **Feature Name Integration**: Updated V3.0 to properly utilize `info.features[key].names`
- **Consistent Grouping**: Applied the same `groupRowBySuffix()` logic used in V2.1 to V3.0 data
- **Column Exclusion**: Exclude `next.done` along with `index`, `task_index`, `episode_index` and `frame_index`

### Testing
- Verified V3.0 datasets now display with proper hierarchical structure
- Confirmed V2.1 datasets continue to work unchanged  
