### PR TITLE
fix: update deployment target to correct Space name

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Push to hub
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: git push https://mishig:$HF_TOKEN@huggingface.co/spaces/lerobot/test-vis main -f
+        run: git push https://mishig:$HF_TOKEN@huggingface.co/spaces/lerobot/visualize_dataset main -f


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow to deploy to the correct Hugging Face Space
- Change deployment target from `lerobot/test-vis` to `lerobot/visualize_dataset`

🤖 Generated with [Claude Code](https://claude.com/claude-code)