### PR TITLE
Improve loading speed, do loading and computation in browser

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, lazy, Suspense, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  lazy,
+  Suspense,
+  useCallback,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { postParentMessageWithParams } from "@/utils/postParentMessage";
 import { SimpleVideosPlayer } from "@/components/simple-videos-player";

--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -209,7 +209,9 @@ function pickProgressColumn(rows: Record<string, unknown>[]): string | null {
   const candidates = [...preferred, ...additionalProgressColumns];
 
   for (const column of candidates) {
-    const hasFiniteValue = rows.some((row) => toFiniteNumber(row[column]) !== null);
+    const hasFiniteValue = rows.some(
+      (row) => toFiniteNumber(row[column]) !== null,
+    );
     if (hasFiniteValue) {
       return column;
     }
@@ -260,13 +262,17 @@ async function loadEpisodeProgressGroup(
       if (orderedPoints.length === 0) continue;
       orderedPoints.sort((a, b) => a.order - b.order);
 
-      const sampledPoints = evenlySampleArray(orderedPoints, MAX_EPISODE_POINTS);
+      const sampledPoints = evenlySampleArray(
+        orderedPoints,
+        MAX_EPISODE_POINTS,
+      );
       const progressKey = buildProgressSeriesKey(progressColumn);
       const denominator = Math.max(sampledPoints.length - 1, 1);
       const duration = Math.max(episodeDuration, 0);
 
       return sampledPoints.map((point, idx) => ({
-        timestamp: sampledPoints.length === 1 ? 0 : (idx / denominator) * duration,
+        timestamp:
+          sampledPoints.length === 1 ? 0 : (idx / denominator) * duration,
         [progressKey]: point.progress,
       }));
     } catch {

--- a/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -25,11 +25,7 @@ export default async function EpisodePage({
   const episodeNumber = Number(episode.replace(/^episode_/, ""));
   return (
     <Suspense fallback={null}>
-      <EpisodeViewer
-        org={org}
-        dataset={dataset}
-        episodeId={episodeNumber}
-      />
+      <EpisodeViewer org={org} dataset={dataset} episodeId={episodeNumber} />
     </Suspense>
   );
 }

--- a/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -1,5 +1,4 @@
 import EpisodeViewer from "./episode-viewer";
-import { getEpisodeDataSafe } from "./fetch-data";
 import { Suspense } from "react";
 
 export const dynamic = "force-dynamic";
@@ -24,10 +23,13 @@ export default async function EpisodePage({
   const { org, dataset, episode } = await params;
   // fetchData should be updated if needed to support this path pattern
   const episodeNumber = Number(episode.replace(/^episode_/, ""));
-  const { data, error } = await getEpisodeDataSafe(org, dataset, episodeNumber);
   return (
     <Suspense fallback={null}>
-      <EpisodeViewer data={data} error={error} org={org} dataset={dataset} />
+      <EpisodeViewer
+        org={org}
+        dataset={dataset}
+        episodeId={episodeNumber}
+      />
     </Suspense>
   );
 }

--- a/src/components/urdf-viewer.tsx
+++ b/src/components/urdf-viewer.tsx
@@ -542,7 +542,10 @@ export default function URDFViewer({
 
   const [selectedGroup, setSelectedGroup] = useState(defaultGroup);
   useEffect(() => setSelectedGroup(defaultGroup), [defaultGroup]);
-  const selectedColumns = columnGroups[selectedGroup] ?? [];
+  const selectedColumns = useMemo(
+    () => columnGroups[selectedGroup] ?? [],
+    [columnGroups, selectedGroup],
+  );
 
   // Joint mapping
   const autoMapping = useMemo(
@@ -640,7 +643,7 @@ export default function URDFViewer({
       }
     }
     return values;
-  }, [chartData, frame, mapping, totalFrames, urdfJointNames]);
+  }, [chartData, frame, gripperRanges, mapping, totalFrames, urdfJointNames]);
 
   const currentTime = totalFrames > 0 ? (frame / fps).toFixed(2) : "0.00";
   const totalTime = (totalFrames / fps).toFixed(2);


### PR DESCRIPTION
Moved initial episode loading to the client so Parquet downloads and parsing happen in the user’s browser instead of the shared backend, reducing memory pressure. Switched stats/frames/insights and URDF episode chart loading to client-side fetches, removing the server-action path. Added guards to prevent async state updates after unmount and reset per-dataset cached UI data when switching datasets. This improves first-load responsiveness on the Space and scales better with multiple concurrent users.

