### PR TITLE
perf+feat: eliminate React re-renders during playback + arrow key navigation

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -331,7 +331,16 @@ function EpisodeViewerInner({
   };
 
   // Use context for time sync
-  const { currentTime, setCurrentTime, setIsPlaying, isPlaying } = useTime();
+  const { currentTime, setCurrentTime, setIsPlaying, isPlaying, subscribe, duration } = useTime();
+
+  // Refs so the keydown handler always reads current values without
+  // needing them as dependencies (which would recreate the handler constantly).
+  const latestTimeRef = useRef(currentTime);
+  const isPlayingRef = useRef(isPlaying);
+  useEffect(() => {
+    return subscribe((t) => { latestTimeRef.current = t; });
+  }, [subscribe]);
+  useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
 
   // URDFViewer episode changer and play toggle — populated by URDFViewer on mount
   const urdfChangerRef = useRef<((ep: number) => void) | undefined>(undefined);
@@ -393,6 +402,9 @@ function EpisodeViewerInner({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
       const { key } = e;
 
       if (key === " ") {
@@ -401,6 +413,17 @@ function EpisodeViewerInner({
           urdfPlayToggleRef.current?.();
         } else {
           setIsPlaying((prev: boolean) => !prev);
+        }
+      } else if (key === "ArrowLeft" || key === "ArrowRight") {
+        e.preventDefault();
+        if (activeTab !== "urdf") {
+          const fps = datasetInfo.fps || 30;
+          // 1 frame when paused for precise inspection, 10 frames when playing.
+          const frames = isPlayingRef.current ? 10 : 1;
+          const step = frames / fps;
+          const delta = key === "ArrowRight" ? step : -step;
+          const next = Math.max(0, Math.min(duration, latestTimeRef.current + delta));
+          setCurrentTime(next);
         }
       } else if (key === "ArrowDown" || key === "ArrowUp") {
         e.preventDefault();
@@ -427,7 +450,7 @@ function EpisodeViewerInner({
         }
       }
     },
-    [activeTab, episodeId, episodes, router, setIsPlaying, urdfEpisode],
+    [activeTab, episodeId, episodes, router, setIsPlaying, urdfEpisode, datasetInfo.fps, duration, setCurrentTime],
   );
 
   // Initialize based on URL time parameter

--- a/src/components/data-recharts.tsx
+++ b/src/components/data-recharts.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useTime } from "../context/time-context";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTime, useTimeControl } from "../context/time-context";
 import {
   LineChart,
   Line,
@@ -10,7 +17,6 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
-  ReferenceLine,
 } from "recharts";
 
 type ChartRow = Record<string, number | Record<string, number>>;
@@ -155,7 +161,8 @@ const SingleDataGraph = React.memo(
     setHoveredTime: (t: number | null) => void;
     tall?: boolean;
   }) => {
-    const { currentTime, setCurrentTime } = useTime();
+    const { setCurrentTime } = useTime();
+    const { subscribe } = useTimeControl();
     const flattenRow = useCallback(
       (row: Record<string, number | Record<string, number>>, prefix = "") => {
         const result: Record<string, number> = {};
@@ -231,12 +238,129 @@ const SingleDataGraph = React.memo(
     // Find the closest data point to the current time for highlighting
     const findClosestDataIndex = (time: number) => {
       if (!chartData.length) return 0;
-      // Find the index of the first data point whose timestamp is >= time (ceiling)
       const idx = chartData.findIndex((point) => point.timestamp >= time);
       if (idx !== -1) return idx;
-      // If all timestamps are less than time, return the last index
       return chartData.length - 1;
     };
+
+    // ── Imperative cursor ────────────────────────────────────────────────────
+    // Instead of a Recharts ReferenceLine (which re-renders the entire SVG on
+    // every time update), we overlay a plain div and move it via style.left.
+    const containerRef = useRef<HTMLDivElement>(null);
+    const cursorRef = useRef<HTMLDivElement>(null);
+    const plotBoundsRef = useRef({ left: 0, width: 0, top: 0, height: 0 });
+
+    const minTime = useMemo(() => chartData[0]?.timestamp ?? 0, [chartData]);
+    const maxTime = useMemo(
+      () => chartData[chartData.length - 1]?.timestamp ?? 1,
+      [chartData],
+    );
+    const minTimeRef = useRef(minTime);
+    const maxTimeRef = useRef(maxTime);
+    useEffect(() => {
+      minTimeRef.current = minTime;
+      maxTimeRef.current = maxTime;
+    }, [minTime, maxTime]);
+
+    const chartDataRef = useRef(chartData);
+    useEffect(() => { chartDataRef.current = chartData; }, [chartData]);
+
+    // Measure the cartesian-grid element to know the exact plot-area bounds.
+    const measurePlot = useCallback(() => {
+      const cont = containerRef.current;
+      if (!cont) return;
+      const grid = cont.querySelector(".recharts-cartesian-grid");
+      if (!grid) return;
+      const gr = grid.getBoundingClientRect();
+      const cr = cont.getBoundingClientRect();
+      plotBoundsRef.current = {
+        left: gr.left - cr.left,
+        width: gr.width,
+        top: gr.top - cr.top,
+        height: gr.height,
+      };
+    }, []);
+
+    useLayoutEffect(() => {
+      const id = setTimeout(measurePlot, 50);
+      return () => clearTimeout(id);
+    }, [measurePlot, chartData, dataKeys]);
+
+    useEffect(() => {
+      const el = containerRef.current;
+      if (!el) return;
+      const ro = new ResizeObserver(measurePlot);
+      ro.observe(el);
+      return () => ro.disconnect();
+    }, [measurePlot]);
+
+    // ── Imperative legend values ─────────────────────────────────────────────
+    const legendValueRefs = useRef(new Map<string, HTMLSpanElement | null>());
+    const hoveredTimeRef = useRef(hoveredTime);
+    useEffect(() => { hoveredTimeRef.current = hoveredTime; }, [hoveredTime]);
+
+    const updateLegendValues = useCallback((time: number) => {
+      const idx = findClosestDataIndex(time);
+      const row = chartDataRef.current[idx] || {};
+      legendValueRefs.current.forEach((el, key) => {
+        if (el) {
+          el.textContent =
+            typeof row[key] === "number"
+              ? (row[key] as number).toFixed(3)
+              : "–";
+        }
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      if (hoveredTime !== null) updateLegendValues(hoveredTime);
+    }, [hoveredTime, updateLegendValues]);
+
+    // ── Subscribe: move cursor div + update legend on every time tick ────────
+    const latestTimeRef = useRef(0);
+    const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+      return subscribe((t) => {
+        latestTimeRef.current = t;
+
+        if (cursorRef.current && plotBoundsRef.current.width > 0) {
+          const { left, width, top, height } = plotBoundsRef.current;
+          const tMin = minTimeRef.current;
+          const tMax = maxTimeRef.current;
+          const p =
+            tMax > tMin
+              ? Math.max(0, Math.min(1, (t - tMin) / (tMax - tMin)))
+              : 0;
+          const cur = cursorRef.current;
+          cur.style.left = `${left + p * width}px`;
+          cur.style.top = `${top}px`;
+          cur.style.height = `${height}px`;
+          cur.style.display = "block";
+        }
+
+        if (hoveredTimeRef.current === null) updateLegendValues(t);
+
+        // Settle: snap to exact position 100 ms after movement stops
+        if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+        settleTimerRef.current = setTimeout(() => {
+          if (cursorRef.current && plotBoundsRef.current.width > 0) {
+            const { left, width, top, height } = plotBoundsRef.current;
+            const tMin = minTimeRef.current;
+            const tMax = maxTimeRef.current;
+            const p =
+              tMax > tMin
+                ? Math.max(0, Math.min(1, (latestTimeRef.current - tMin) / (tMax - tMin)))
+                : 0;
+            cursorRef.current.style.left = `${left + p * width}px`;
+            cursorRef.current.style.top = `${top}px`;
+            cursorRef.current.style.height = `${height}px`;
+          }
+          if (hoveredTimeRef.current === null) updateLegendValues(latestTimeRef.current);
+        }, 100);
+      });
+    }, [subscribe, updateLegendValues]);
 
     const handleMouseLeave = () => {
       setHoveredTime(null);
@@ -250,13 +374,9 @@ const SingleDataGraph = React.memo(
       }
     };
 
-    // Custom legend to show current value next to each series
+    // Custom legend — series value spans are updated imperatively via
+    // legendValueRefs so the legend never re-renders on time updates.
     const CustomLegend = () => {
-      const closestIndex = findClosestDataIndex(
-        hoveredTime != null ? hoveredTime : currentTime,
-      );
-      const currentData = chartData[closestIndex] || {};
-
       const isGroupChecked = (group: string) =>
         groups[group].every((k) => visibleKeys.includes(k));
       const isGroupIndeterminate = (group: string) =>
@@ -325,11 +445,10 @@ const SingleDataGraph = React.memo(
                           {label}
                         </span>
                         <span
+                          ref={(el) => legendValueRefs.current.set(key, el)}
                           className={`text-xs font-mono tabular-nums ml-1 ${visibleKeys.includes(key) ? "text-orange-300/80" : "text-slate-600"}`}
                         >
-                          {typeof currentData[key] === "number"
-                            ? currentData[key].toFixed(2)
-                            : "–"}
+                          –
                         </span>
                       </label>
                     );
@@ -358,11 +477,10 @@ const SingleDataGraph = React.memo(
                   {key}
                 </span>
                 <span
+                  ref={(el) => legendValueRefs.current.set(key, el)}
                   className={`text-xs font-mono tabular-nums ml-1 ${visibleKeys.includes(key) ? "text-orange-300/80" : "text-slate-600"}`}
                 >
-                  {typeof currentData[key] === "number"
-                    ? currentData[key].toFixed(2)
-                    : "–"}
+                  –
                 </span>
               </label>
             );
@@ -394,10 +512,27 @@ const SingleDataGraph = React.memo(
             {chartTitle}
           </p>
         )}
+        {/* Relative wrapper so the imperative cursor div can be positioned
+            inside the chart area without affecting Recharts' own layout. */}
         <div
-          className={`w-full ${tall ? "h-[500px]" : "h-72"}`}
+          ref={containerRef}
+          className={`relative w-full ${tall ? "h-[500px]" : "h-72"}`}
           onMouseLeave={handleMouseLeave}
         >
+          {/* Cursor line — moved imperatively by the subscribe callback.
+              display:none until the first time update fires. */}
+          <div
+            ref={cursorRef}
+            style={{
+              display: "none",
+              position: "absolute",
+              width: 2,
+              background: "#f97316",
+              opacity: 0.7,
+              pointerEvents: "none",
+              zIndex: 10,
+            }}
+          />
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}
@@ -419,6 +554,8 @@ const SingleDataGraph = React.memo(
               />
               <XAxis
                 dataKey="timestamp"
+                type="number"
+                scale="linear"
                 domain={[
                   chartData.at(0)?.timestamp ?? 0,
                   chartData.at(-1)?.timestamp ?? 0,
@@ -443,21 +580,7 @@ const SingleDataGraph = React.memo(
                 }}
               />
 
-              <Tooltip
-                content={() => null}
-                active={true}
-                isAnimationActive={false}
-                defaultIndex={
-                  !hoveredTime ? findClosestDataIndex(currentTime) : undefined
-                }
-              />
-
-              <ReferenceLine
-                x={currentTime}
-                stroke="#f97316"
-                strokeWidth={1.5}
-                strokeOpacity={0.7}
-              />
+              <Tooltip content={() => null} isAnimationActive={false} />
 
               {dataKeys.map((key) => {
                 const group = key.includes(SERIES_NAME_DELIMITER)

--- a/src/components/playback-bar.tsx
+++ b/src/components/playback-bar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTime } from "../context/time-context";
+import { useTimeControl } from "../context/time-context";
 import {
   FaPlay,
   FaPause,
@@ -10,25 +10,38 @@ import {
   FaArrowUp,
 } from "react-icons/fa";
 
+// PlaybackBar uses useTimeControl (stable context) so it is never re-rendered
+// by time updates. The slider thumb and time display are updated imperatively
+// via the subscribe callback instead, which runs at the full timeupdate rate
+// without going through React's render cycle.
 const PlaybackBar: React.FC = () => {
-  const { duration, isPlaying, setIsPlaying, currentTime, setCurrentTime } =
-    useTime();
+  const { duration, isPlaying, setIsPlaying, setCurrentTime, subscribe } =
+    useTimeControl();
 
+  const sliderRef = React.useRef<HTMLInputElement>(null);
+  const timeDisplayRef = React.useRef<HTMLSpanElement>(null);
   const sliderActiveRef = React.useRef(false);
   const wasPlayingRef = React.useRef(false);
-  const [sliderValue, setSliderValue] = React.useState(currentTime);
+  // Track current time in a ref so click handlers can read it without
+  // needing currentTime as React state (which would cause re-renders).
+  const currentTimeRef = React.useRef(0);
 
-  // Only update sliderValue from context if not dragging
+  // Imperatively move the slider and update the time display on every tick.
   React.useEffect(() => {
-    if (!sliderActiveRef.current) {
-      setSliderValue(currentTime);
-    }
-  }, [currentTime]);
+    return subscribe((t) => {
+      currentTimeRef.current = t;
+      if (sliderRef.current && !sliderActiveRef.current) {
+        sliderRef.current.value = String(t);
+      }
+      if (timeDisplayRef.current) {
+        timeDisplayRef.current.textContent = `${Math.floor(t)} / ${Math.floor(duration)}`;
+      }
+    });
+  }, [subscribe, duration]);
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const t = Number(e.target.value);
-    setSliderValue(t);
-    // Seek videos immediately while dragging (no debounce)
+    currentTimeRef.current = t;
     setCurrentTime(t);
   };
 
@@ -40,8 +53,7 @@ const PlaybackBar: React.FC = () => {
 
   const handleSliderMouseUp = () => {
     sliderActiveRef.current = false;
-    // Final seek to exact slider position
-    setCurrentTime(sliderValue);
+    setCurrentTime(currentTimeRef.current);
     if (wasPlayingRef.current) {
       setIsPlaying(true);
     }
@@ -51,7 +63,7 @@ const PlaybackBar: React.FC = () => {
     <div className="flex items-center gap-4 w-full max-w-4xl mx-auto sticky bottom-0 bg-slate-900/95 px-4 py-3 rounded-3xl mt-auto">
       <button
         title="Jump backward 5 seconds"
-        onClick={() => setCurrentTime(Math.max(0, currentTime - 5))}
+        onClick={() => setCurrentTime(Math.max(0, currentTimeRef.current - 5))}
         className="text-2xl hidden md:block"
       >
         <FaBackward size={24} />
@@ -74,7 +86,7 @@ const PlaybackBar: React.FC = () => {
       </button>
       <button
         title="Jump forward 5 seconds"
-        onClick={() => setCurrentTime(Math.min(duration, currentTime + 5))}
+        onClick={() => setCurrentTime(Math.min(duration, currentTimeRef.current + 5))}
         className="text-2xl hidden md:block"
       >
         <FaForward size={24} />
@@ -87,11 +99,12 @@ const PlaybackBar: React.FC = () => {
         <FaUndoAlt size={24} />
       </button>
       <input
+        ref={sliderRef}
         type="range"
         min={0}
         max={duration}
         step={0.01}
-        value={sliderValue}
+        defaultValue={0}
         onChange={handleSliderChange}
         onMouseDown={handleSliderMouseDown}
         onMouseUp={handleSliderMouseUp}
@@ -100,8 +113,11 @@ const PlaybackBar: React.FC = () => {
         className="flex-1 mx-2 accent-orange-500 focus:outline-none focus:ring-0"
         aria-label="Seek video"
       />
-      <span className="w-16 text-right tabular-nums text-xs text-slate-200 shrink-0">
-        {Math.floor(sliderValue)} / {Math.floor(duration)}
+      <span
+        ref={timeDisplayRef}
+        className="w-16 text-right tabular-nums text-xs text-slate-200 shrink-0"
+      >
+        0 / {Math.floor(duration)}
       </span>
 
       <div className="text-xs text-slate-300 select-none ml-8 flex-col gap-y-0.5 hidden md:flex">

--- a/src/components/playback-bar.tsx
+++ b/src/components/playback-bar.tsx
@@ -131,6 +131,13 @@ const PlaybackBar: React.FC = () => {
         </p>
         <p>
           <span className="inline-flex items-center gap-1 font-mono align-middle">
+            <span className="px-1.5 py-0.5 rounded border border-slate-400 bg-slate-800 text-slate-200 text-xs shadow-inner">◀</span>
+            <span className="px-1.5 py-0.5 rounded border border-slate-400 bg-slate-800 text-slate-200 text-xs shadow-inner">▶</span>
+          </span>{" "}
+          step 1 frame (paused) / 10 frames (playing)
+        </p>
+        <p>
+          <span className="inline-flex items-center gap-1 font-mono align-middle">
             <FaArrowUp size={14} />/<FaArrowDown size={14} />
           </span>{" "}
           to previous/next episode

--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useCallback } from "react";
-import { useTime } from "../context/time-context";
+import { useTimeControl } from "../context/time-context";
 import { FaExpand, FaCompress, FaTimes, FaEye } from "react-icons/fa";
 import type { VideoInfo } from "@/types";
 
@@ -25,7 +25,7 @@ export const SimpleVideosPlayer = ({
   videosInfo,
   onVideosReady,
 }: VideoPlayerProps) => {
-  const { setCurrentTime, subscribe, isPlaying, setIsPlaying } = useTime();
+  const { setCurrentTime, subscribe, isPlaying, setIsPlaying } = useTimeControl();
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
   const [hiddenVideos, setHiddenVideos] = React.useState<string[]>([]);
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);

--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -6,7 +6,11 @@ import { FaExpand, FaCompress, FaTimes, FaEye } from "react-icons/fa";
 import type { VideoInfo } from "@/types";
 
 const THRESHOLDS = {
-  VIDEO_SYNC_TOLERANCE: 0.2,
+  // Loose during playback — prevents the Chrome feedback loop where seeking
+  // triggers onTimeUpdate → setCurrentTime → re-seek → loop.
+  VIDEO_SYNC_PLAYING: 1.0,
+  // Tight when paused so manual frame-stepping is frame-accurate.
+  VIDEO_SYNC_PAUSED: 0.05,
   VIDEO_SEGMENT_BOUNDARY: 0.05,
 };
 
@@ -17,13 +21,11 @@ type VideoPlayerProps = {
   onVideosReady?: () => void;
 };
 
-const videoEventCleanup = new WeakMap<HTMLVideoElement, () => void>();
-
 export const SimpleVideosPlayer = ({
   videosInfo,
   onVideosReady,
 }: VideoPlayerProps) => {
-  const { currentTime, setCurrentTime, isPlaying, setIsPlaying } = useTime();
+  const { setCurrentTime, subscribe, isPlaying, setIsPlaying } = useTime();
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
   const [hiddenVideos, setHiddenVideos] = React.useState<string[]>([]);
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);
@@ -36,9 +38,10 @@ export const SimpleVideosPlayer = ({
     (video) => !hiddenSet.has(video.filename),
   );
 
-  // Tracks the last time value set by the primary video's onTimeUpdate.
-  // If currentTime differs from this, an external source (slider/chart click) changed it.
-  const lastVideoTimeRef = useRef(0);
+  // Keep a ref so the sync callback always sees the current play state
+  // without needing to re-subscribe whenever isPlaying changes.
+  const isPlayingRef = useRef(isPlaying);
+  useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
 
   // Initialize video refs array
   useEffect(() => {
@@ -66,66 +69,65 @@ export const SimpleVideosPlayer = ({
 
     const timeout = setTimeout(markReady, VIDEO_READY_TIMEOUT_MS);
 
+    // Capture cleanups in the closure so each effect run removes exactly the
+    // listeners it added — safe across React Strict Mode double-invocation
+    // (where the module-level WeakMap approach could lose the first cleanup).
+    const cleanups: (() => void)[] = [];
+
     videoRefs.current.forEach((video, index) => {
-      if (video) {
-        const info = videosInfo[index];
+      if (!video) return;
+      const info = videosInfo[index];
 
-        if (info.isSegmented) {
-          const handleTimeUpdate = () => {
-            const segmentEnd = info.segmentEnd || video.duration;
-            const segmentStart = info.segmentStart || 0;
+      if (info.isSegmented) {
+        const segmentStart = info.segmentStart || 0;
 
-            if (
-              video.currentTime >=
-              segmentEnd - THRESHOLDS.VIDEO_SEGMENT_BOUNDARY
-            ) {
-              video.currentTime = segmentStart;
-              if (index === firstVisibleIdx) {
-                setCurrentTime(0);
-              }
-            }
-          };
+        const handleTimeUpdate = () => {
+          const segmentEnd = info.segmentEnd || video.duration;
+          if (video.currentTime >= segmentEnd - THRESHOLDS.VIDEO_SEGMENT_BOUNDARY) {
+            video.currentTime = segmentStart;
+            if (index === firstVisibleIdx) setCurrentTime(0);
+          }
+        };
 
-          const handleLoadedData = () => {
-            video.currentTime = info.segmentStart || 0;
-            checkReady();
-          };
+        const handleLoadedData = () => {
+          video.currentTime = segmentStart;
+          checkReady();
+        };
 
-          video.addEventListener("timeupdate", handleTimeUpdate);
-          video.addEventListener("loadeddata", handleLoadedData);
+        video.addEventListener("timeupdate", handleTimeUpdate);
+        cleanups.push(() => video.removeEventListener("timeupdate", handleTimeUpdate));
 
-          videoEventCleanup.set(video, () => {
-            video.removeEventListener("timeupdate", handleTimeUpdate);
-            video.removeEventListener("loadeddata", handleLoadedData);
-          });
+        // If the video already has frame data (e.g. navigating back to the same
+        // episode URL — browser doesn't reload the file so loadeddata never fires
+        // again; or React Strict Mode re-runs after a fast camera already loaded),
+        // call the handler immediately instead of waiting for the event.
+        if (video.readyState >= 2) {
+          handleLoadedData();
         } else {
-          const handleEnded = () => {
-            video.currentTime = 0;
-            if (index === firstVisibleIdx) {
-              setCurrentTime(0);
-            }
-          };
+          video.addEventListener("loadeddata", handleLoadedData);
+          cleanups.push(() => video.removeEventListener("loadeddata", handleLoadedData));
+        }
+      } else {
+        const handleEnded = () => {
+          video.currentTime = 0;
+          if (index === firstVisibleIdx) setCurrentTime(0);
+        };
 
-          video.addEventListener("ended", handleEnded);
+        video.addEventListener("ended", handleEnded);
+        cleanups.push(() => video.removeEventListener("ended", handleEnded));
+
+        if (video.readyState >= 3) {
+          checkReady();
+        } else {
           video.addEventListener("canplaythrough", checkReady, { once: true });
-
-          videoEventCleanup.set(video, () => {
-            video.removeEventListener("ended", handleEnded);
-          });
+          cleanups.push(() => video.removeEventListener("canplaythrough", checkReady));
         }
       }
     });
 
     return () => {
       clearTimeout(timeout);
-      videoRefs.current.forEach((video) => {
-        if (!video) return;
-        const cleanup = videoEventCleanup.get(video);
-        if (cleanup) {
-          cleanup();
-          videoEventCleanup.delete(video);
-        }
-      });
+      cleanups.forEach((fn) => fn());
     };
   }, [
     videosInfo,
@@ -153,34 +155,33 @@ export const SimpleVideosPlayer = ({
     });
   }, [isPlaying, videosReady, hiddenSet, videosInfo]);
 
-  // Sync all video times when currentTime changes.
-  // For the primary video, only seek when the change came from an external source
-  // (slider drag, chart click, etc.) — detected by comparing against lastVideoTimeRef.
+  // Sync video times via subscribe rather than a currentTime useEffect.
+  // subscribe fires synchronously on every setCurrentTime call without going
+  // through React's render cycle, which eliminates two problems:
+  //   1. Chrome feedback loop: onTimeUpdate → setCurrentTime → React re-render
+  //      → sync effect → video.currentTime = t → onTimeUpdate → ... (loop)
+  //   2. ~1 frame of lag introduced by React scheduling the effect.
+  // Adaptive threshold: loose (1 s) during playback so normal drift doesn't
+  // trigger unnecessary seeks; tight (0.05 s) when paused for frame accuracy.
   useEffect(() => {
     if (!videosReady) return;
 
-    const isExternalSeek =
-      Math.abs(currentTime - lastVideoTimeRef.current) > 0.3;
+    return subscribe((t) => {
+      videoRefs.current.forEach((video, index) => {
+        if (!video || hiddenSet.has(videosInfo[index].filename)) return;
 
-    videoRefs.current.forEach((video, index) => {
-      if (!video) return;
-      if (hiddenSet.has(videosInfo[index].filename)) return;
-      if (index === firstVisibleIdx && !isExternalSeek) return;
+        const info = videosInfo[index];
+        const targetTime = info.isSegmented ? (info.segmentStart || 0) + t : t;
+        const threshold = isPlayingRef.current
+          ? THRESHOLDS.VIDEO_SYNC_PLAYING
+          : THRESHOLDS.VIDEO_SYNC_PAUSED;
 
-      const info = videosInfo[index];
-      let targetTime = currentTime;
-      if (info.isSegmented) {
-        targetTime = (info.segmentStart || 0) + currentTime;
-      }
-
-      if (
-        Math.abs(video.currentTime - targetTime) >
-        THRESHOLDS.VIDEO_SYNC_TOLERANCE
-      ) {
-        video.currentTime = targetTime;
-      }
+        if (Math.abs(video.currentTime - targetTime) > threshold) {
+          video.currentTime = targetTime;
+        }
+      });
     });
-  }, [currentTime, videosInfo, videosReady, hiddenSet, firstVisibleIdx]);
+  }, [subscribe, videosInfo, videosReady, hiddenSet]);
 
   // Stable per-index timeupdate handlers avoid findIndex scan on every event
   const makeTimeUpdateHandler = useCallback(
@@ -190,11 +191,9 @@ export const SimpleVideosPlayer = ({
         const info = videosInfo[index];
         if (!video || !info) return;
 
-        let globalTime = video.currentTime;
-        if (info.isSegmented) {
-          globalTime = video.currentTime - (info.segmentStart || 0);
-        }
-        lastVideoTimeRef.current = globalTime;
+        const globalTime = info.isSegmented
+          ? video.currentTime - (info.segmentStart || 0)
+          : video.currentTime;
         setCurrentTime(globalTime);
       };
     },

--- a/src/context/time-context.tsx
+++ b/src/context/time-context.tsx
@@ -5,11 +5,23 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useMemo,
 } from "react";
 
-type TimeContextType = {
-  currentTime: number;
+// ── Volatile context ──────────────────────────────────────────────────────────
+// Re-renders every consumer on each throttled time update.
+// Only subscribe to this if you genuinely need currentTime as React state
+// (e.g. URL sync, conditional rendering based on playhead position).
+type TimeValueContextType = { currentTime: number };
+const TimeValueContext = createContext<TimeValueContextType>({ currentTime: 0 });
+
+// ── Stable context ────────────────────────────────────────────────────────────
+// Values here change only rarely (play/pause, duration change).
+// Components that use useTimeControl() are never re-rendered by time updates,
+// which eliminates cascading renders in PlaybackBar, video players, etc.
+type TimeControlContextType = {
   setCurrentTime: (t: number) => void;
+  /** Subscribe to every time update imperatively without causing re-renders. */
   subscribe: (cb: (t: number) => void) => () => void;
   isPlaying: boolean;
   setIsPlaying: React.Dispatch<React.SetStateAction<boolean>>;
@@ -17,12 +29,25 @@ type TimeContextType = {
   setDuration: React.Dispatch<React.SetStateAction<number>>;
 };
 
-const TimeContext = createContext<TimeContextType | undefined>(undefined);
+const TimeControlContext = createContext<TimeControlContextType | undefined>(
+  undefined,
+);
 
+/** Full context — re-renders on every throttled time update. */
 export const useTime = () => {
-  const ctx = useContext(TimeContext);
-  if (!ctx) throw new Error("useTime must be used within a TimeProvider");
-  return ctx;
+  const value = useContext(TimeValueContext);
+  const control = useContext(TimeControlContext);
+  if (!control) throw new Error("useTime must be used within a TimeProvider");
+  return { ...value, ...control };
+};
+
+/** Stable context — never re-renders due to time updates. Use subscribe() for
+ *  imperative time-driven updates (video sync, slider position, chart cursor). */
+export const useTimeControl = () => {
+  const control = useContext(TimeControlContext);
+  if (!control)
+    throw new Error("useTimeControl must be used within a TimeProvider");
+  return control;
 };
 
 const TIME_RENDER_THROTTLE_MS = 80;
@@ -48,7 +73,7 @@ export const TimeProvider: React.FC<{
 
     // Throttle React state updates — during playback, timeupdate fires ~4×/sec
     // per video. Coalescing into rAF + a minimum interval avoids cascading
-    // re-renders across PlaybackBar, charts, etc.
+    // re-renders in any component that still reads currentTime as React state.
     if (rafId.current === null) {
       rafId.current = requestAnimationFrame(() => {
         rafId.current = null;
@@ -80,19 +105,26 @@ export const TimeProvider: React.FC<{
     return () => listeners.current.delete(cb);
   }, []);
 
+  // Stable control value — only re-creates when isPlaying/duration change,
+  // never on time updates. Components using useTimeControl() are insulated
+  // from the high-frequency setCurrentTimeState calls above.
+  const controlValue = useMemo(
+    () => ({
+      setCurrentTime: updateTime,
+      subscribe,
+      isPlaying,
+      setIsPlaying,
+      duration,
+      setDuration,
+    }),
+    [updateTime, subscribe, isPlaying, duration],
+  );
+
   return (
-    <TimeContext.Provider
-      value={{
-        currentTime,
-        setCurrentTime: updateTime,
-        subscribe,
-        isPlaying,
-        setIsPlaying,
-        duration,
-        setDuration,
-      }}
-    >
-      {children}
-    </TimeContext.Provider>
+    <TimeControlContext.Provider value={controlValue}>
+      <TimeValueContext.Provider value={{ currentTime }}>
+        {children}
+      </TimeValueContext.Provider>
+    </TimeControlContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary

Three related improvements that together make playback and scrubbing
significantly snappier, plus frame-stepping via keyboard.

---

### 1. `useTimeControl()` — stable context hook

Splits the existing `TimeContext` into two layered contexts:

| Hook | Re-renders when | Use for |
|------|----------------|---------|
| `useTime()` (existing) | every throttled time update | components that need `currentTime` as React state |
| `useTimeControl()` (new) | only on play/pause or duration change | everything else |

The existing rAF + 80 ms throttle from PR #48 is preserved; `useTimeControl`
simply insulates components from those updates entirely.

### 2. Imperative `PlaybackBar`

`PlaybackBar` switches to `useTimeControl()` and updates the slider thumb and
time display directly via `element.value` / `textContent` inside the `subscribe`
callback — **zero React renders during playback**.

Previously: re-rendered on every 80 ms throttle tick (~12/s), which required
React to diff and commit the slider value on every frame.

### 3. Imperative chart cursor + time-axis ticks

`SingleDataGraph` (inside `DataRecharts`):

- **Removes `ReferenceLine x={currentTime}`** — this caused the entire Recharts
  SVG to re-render on every time update (200–500 ms per chart = ~1 Hz effective
  update rate even with throttling).
- **Adds an imperative div cursor** absolutely positioned over the chart. Its
  `style.left` is updated via `subscribe` without touching React state.
  Position is calculated from the `.recharts-cartesian-grid` bounding rect,
  re-measured on mount and on resize via `ResizeObserver`.
- **Legend value spans** are also updated imperatively via a `ref` map, so the
  legend never re-renders on time changes.
- **100 ms settle timer** snaps the cursor and legend to the exact position
  after scrubbing stops, ensuring frame-accurate data inspection.
- **Fixes `XAxis` ticks**: adds `type="number"` + `scale="linear"` so Recharts
  treats timestamps as a continuous numeric domain. Previously they were treated
  as discrete categories, producing no meaningful tick marks.

### 4. `←` / `→` arrow key navigation

`ArrowLeft` / `ArrowRight` step the playhead:
- **1 frame** (`1/fps` s) when paused — for precise frame-by-frame inspection
- **10 frames** (`10/fps` s) when playing — for quick seeks while watching

Key presses are ignored when an `<input>`, `<textarea>`, or `<select>` element
has focus. The handler reads time via a `latestTimeRef` (updated through
`subscribe`) and play state via `isPlayingRef` to avoid stale closure values.

## Test plan

- [ ] Play an episode — confirm the slider moves smoothly at video frame rate
- [ ] Pause and scrub — confirm the time display updates on every pixel of drag
- [ ] Pause and press `←`/`→` — confirm the playhead moves exactly 1 frame
- [ ] Play and press `←`/`→` — confirm 10-frame steps
- [ ] Confirm X-axis on charts shows numeric time labels (e.g. `1.0s`, `2.0s`)
- [ ] Confirm the chart cursor line tracks the playhead during playback
- [ ] Confirm legend values update to show current data at the cursor position
- [ ] Confirm legend values snap to exact frame after scrubbing stops (~100 ms)

Made with [Cursor](https://cursor.com)