### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -15,13 +15,13 @@ jobs:
   sync-to-hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           lfs: true
           ref: main
       - name: Sync to HF Space
-        uses: huggingface/hub-sync@main
+        uses: huggingface/hub-sync@4d340790b2a7cc86e598dce1c29a0c7c6adf3d62  # main
         with:
           github_repo_id: huggingface/lerobot-dataset-visualizer
           huggingface_repo_id: lerobot/visualize_dataset


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `deploy-release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `deploy-release.yml` | `huggingface/hub-sync` | `main` | `main` | `4d340790b2a7…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#161