### PR TITLE
Add support for loading local datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `src/app/page.tsx` or other files in the `src/` directory. The app supports hot-reloading for rapid development.
 
+### Loading Local Datasets
+
+You can also open a local LeRobot dataset directory instead of fetching a dataset from the Hub.
+
+- Enter an absolute local path such as `/data/lerobot/my_dataset` on the home page
+- The app expects a standard LeRobot layout with `meta/`, `data/`, and `videos/`
+- The Next.js server process must be able to read the dataset directory
+
+When using Docker, mount the dataset directory into the container and use the in-container path when opening it from the app.
+
 ### Other Commands
 
 ```bash

--- a/src/app/[org]/[dataset]/[episode]/actions.ts
+++ b/src/app/[org]/[dataset]/[episode]/actions.ts
@@ -2,21 +2,43 @@
 
 import { getDatasetVersionAndInfo } from "@/utils/versionUtils";
 import type { DatasetMetadata } from "@/utils/parquetUtils";
+import { buildDatasetId } from "@/utils/datasetSource";
+import type { AdjacentEpisodeVideos } from "@/types";
 import {
+  getAdjacentEpisodesVideoInfo,
+  getEpisodeDataSafe,
   loadAllEpisodeLengthsV3,
   loadAllEpisodeFrameInfo,
   loadCrossEpisodeActionVariance,
   loadEpisodeFlatChartData,
+  type EpisodeData,
   type EpisodeLengthStats,
   type EpisodeFramesData,
   type CrossEpisodeVarianceData,
 } from "./fetch-data";
 
+export async function fetchEpisodeDataSafe(
+  org: string,
+  dataset: string,
+  episodeId: number,
+): Promise<{ data?: EpisodeData; error?: string }> {
+  return getEpisodeDataSafe(org, dataset, episodeId);
+}
+
+export async function fetchAdjacentEpisodeVideos(
+  org: string,
+  dataset: string,
+  episodeId: number,
+  range = 1,
+): Promise<AdjacentEpisodeVideos[]> {
+  return getAdjacentEpisodesVideoInfo(org, dataset, episodeId, range);
+}
+
 export async function fetchEpisodeLengthStats(
   org: string,
   dataset: string,
 ): Promise<EpisodeLengthStats | null> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   const { version, info } = await getDatasetVersionAndInfo(repoId);
   if (version !== "v3.0") return null;
   return loadAllEpisodeLengthsV3(repoId, version, info.fps);
@@ -26,7 +48,7 @@ export async function fetchEpisodeFrames(
   org: string,
   dataset: string,
 ): Promise<EpisodeFramesData> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   const { version, info } = await getDatasetVersionAndInfo(repoId);
   return loadAllEpisodeFrameInfo(
     repoId,
@@ -39,7 +61,7 @@ export async function fetchCrossEpisodeVariance(
   org: string,
   dataset: string,
 ): Promise<CrossEpisodeVarianceData | null> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   const { version, info } = await getDatasetVersionAndInfo(repoId);
   return loadCrossEpisodeActionVariance(
     repoId,
@@ -54,7 +76,7 @@ export async function fetchEpisodeChartData(
   dataset: string,
   episodeId: number,
 ): Promise<Record<string, number>[]> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   const { version, info } = await getDatasetVersionAndInfo(repoId);
   return loadEpisodeFlatChartData(
     repoId,

--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -21,20 +21,19 @@ import OverviewPanel from "@/components/overview-panel";
 import Loading from "@/components/loading-component";
 import { hasURDFSupport } from "@/lib/so101-robot";
 import {
-  getAdjacentEpisodesVideoInfo,
-  computeColumnMinMax,
-  getEpisodeDataSafe,
-  loadAllEpisodeLengthsV3,
-  loadAllEpisodeFrameInfo,
-  loadCrossEpisodeActionVariance,
   type EpisodeData,
+  type ChartRow,
   type ColumnMinMax,
   type EpisodeLengthStats,
   type EpisodeFramesData,
   type CrossEpisodeVarianceData,
 } from "./fetch-data";
-import { getDatasetVersionAndInfo } from "@/utils/versionUtils";
-import type { DatasetMetadata } from "@/utils/parquetUtils";
+import {
+  fetchAdjacentEpisodeVideos,
+  fetchCrossEpisodeVariance,
+  fetchEpisodeFrames,
+  fetchEpisodeLengthStats,
+} from "./actions";
 
 const URDFViewer = lazy(() => import("@/components/urdf-viewer"));
 const ActionInsightsPanel = lazy(
@@ -54,41 +53,22 @@ export default function EpisodeViewer({
   org,
   dataset,
   episodeId,
+  initialData,
+  initialError,
 }: {
   org: string;
   dataset: string;
   episodeId: number;
+  initialData: EpisodeData | null;
+  initialError: string | null;
 }) {
-  const [data, setData] = useState<EpisodeData | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const requestIdRef = useRef(0);
+  const [data, setData] = useState<EpisodeData | null>(initialData);
+  const [error, setError] = useState<string | null>(initialError);
 
   useEffect(() => {
-    if (Number.isNaN(episodeId)) {
-      setError("Invalid episode id.");
-      setData(null);
-      return;
-    }
-    const requestId = ++requestIdRef.current;
-    setError(null);
-    setData(null);
-    getEpisodeDataSafe(org, dataset, episodeId)
-      .then(({ data: loaded, error: loadError }) => {
-        if (requestIdRef.current !== requestId) return;
-        if (loadError) {
-          setError(loadError);
-          setData(null);
-          return;
-        }
-        setData(loaded ?? null);
-      })
-      .catch((err) => {
-        if (requestIdRef.current !== requestId) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setError(message || "Unknown error");
-        setData(null);
-      });
-  }, [org, dataset, episodeId]);
+    setData(initialData);
+    setError(initialError);
+  }, [initialData, initialError, org, dataset, episodeId]);
 
   if (error) {
     return (
@@ -171,6 +151,56 @@ function EpisodeViewerInner({
   const [insightsLoading, setInsightsLoading] = useState(false);
   const insightsLoadedRef = useRef(false);
   const mountedRef = useRef(true);
+  const datasetId = org && dataset ? `${org}/${dataset}` : null;
+
+  const computeColumnMinMax = useCallback(
+    (groups: ChartRow[][]): ColumnMinMax[] => {
+      const stats: Record<string, { min: number; max: number }> = {};
+
+      for (const group of groups) {
+        for (const row of group) {
+          for (const [key, value] of Object.entries(row)) {
+            if (key === "timestamp") continue;
+
+            if (typeof value === "number" && Number.isFinite(value)) {
+              if (!stats[key]) {
+                stats[key] = { min: value, max: value };
+              } else {
+                if (value < stats[key].min) stats[key].min = value;
+                if (value > stats[key].max) stats[key].max = value;
+              }
+              continue;
+            }
+
+            if (typeof value !== "object" || value === null) {
+              continue;
+            }
+
+            for (const [subKey, subVal] of Object.entries(value)) {
+              if (typeof subVal !== "number" || !Number.isFinite(subVal)) {
+                continue;
+              }
+
+              const fullKey = `${key} | ${subKey}`;
+              if (!stats[fullKey]) {
+                stats[fullKey] = { min: subVal, max: subVal };
+              } else {
+                if (subVal < stats[fullKey].min) stats[fullKey].min = subVal;
+                if (subVal > stats[fullKey].max) stats[fullKey].max = subVal;
+              }
+            }
+          }
+        }
+      }
+
+      return Object.entries(stats).map(([column, { min, max }]) => ({
+        column,
+        min: Math.round(min * 1000) / 1000,
+        max: Math.round(max * 1000) / 1000,
+      }));
+    },
+    [],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -232,18 +262,13 @@ function EpisodeViewerInner({
     sessionStorage.setItem("framesFlaggedOnly", String(framesFlaggedOnly));
   }, [framesFlaggedOnly]);
 
-  const loadStats = () => {
+  const loadStats = useCallback(() => {
     if (statsLoadedRef.current) return;
     statsLoadedRef.current = true;
     setStatsLoading(true);
     setColumnMinMax(computeColumnMinMax(data.chartDataGroups));
-    if (org && dataset) {
-      const repoId = `${org}/${dataset}`;
-      getDatasetVersionAndInfo(repoId)
-        .then(({ version, info }) => {
-          if (version !== "v3.0") return null;
-          return loadAllEpisodeLengthsV3(repoId, version, info.fps);
-        })
+    if (datasetId) {
+      fetchEpisodeLengthStats(org!, dataset!)
         .then((result) => {
           if (!mountedRef.current) return;
           setEpisodeLengthStats(result);
@@ -255,21 +280,13 @@ function EpisodeViewerInner({
     } else {
       setStatsLoading(false);
     }
-  };
+  }, [computeColumnMinMax, data.chartDataGroups, datasetId, dataset, org]);
 
-  const loadFrames = () => {
-    if (framesLoadedRef.current || !org || !dataset) return;
+  const loadFrames = useCallback(() => {
+    if (framesLoadedRef.current || !datasetId) return;
     framesLoadedRef.current = true;
     setFramesLoading(true);
-    const repoId = `${org}/${dataset}`;
-    getDatasetVersionAndInfo(repoId)
-      .then(({ version, info }) =>
-        loadAllEpisodeFrameInfo(
-          repoId,
-          version,
-          info as unknown as DatasetMetadata,
-        ),
-      )
+    fetchEpisodeFrames(org!, dataset!)
       .then((result) => {
         if (!mountedRef.current) return;
         setEpisodeFramesData(result);
@@ -281,22 +298,13 @@ function EpisodeViewerInner({
       .finally(() => {
         if (mountedRef.current) setFramesLoading(false);
       });
-  };
+  }, [datasetId, dataset, org]);
 
-  const loadInsights = () => {
-    if (insightsLoadedRef.current || !org || !dataset) return;
+  const loadInsights = useCallback(() => {
+    if (insightsLoadedRef.current || !datasetId) return;
     insightsLoadedRef.current = true;
     setInsightsLoading(true);
-    const repoId = `${org}/${dataset}`;
-    getDatasetVersionAndInfo(repoId)
-      .then(({ version, info }) =>
-        loadCrossEpisodeActionVariance(
-          repoId,
-          version,
-          info as unknown as DatasetMetadata,
-          info.fps,
-        ),
-      )
+    fetchCrossEpisodeVariance(org!, dataset!)
       .then((result) => {
         if (!mountedRef.current) return;
         setCrossEpData(result);
@@ -305,7 +313,7 @@ function EpisodeViewerInner({
       .finally(() => {
         if (mountedRef.current) setInsightsLoading(false);
       });
-  };
+  }, [datasetId, dataset, org]);
 
   // Re-trigger data loading for the restored tab on mount
   useEffect(() => {
@@ -319,16 +327,19 @@ function EpisodeViewerInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleTabChange = (tab: ActiveTab) => {
-    setActiveTab(tab);
-    if (tab === "statistics") loadStats();
-    if (tab === "frames") loadFrames();
-    if (tab === "insights") loadInsights();
-    if (tab === "filtering") {
-      loadStats();
-      loadInsights();
-    }
-  };
+  const handleTabChange = useCallback(
+    (tab: ActiveTab) => {
+      setActiveTab(tab);
+      if (tab === "statistics") loadStats();
+      if (tab === "frames") loadFrames();
+      if (tab === "insights") loadInsights();
+      if (tab === "filtering") {
+        loadStats();
+        loadInsights();
+      }
+    },
+    [loadFrames, loadInsights, loadStats],
+  );
 
   // Use context for time sync
   const { currentTime, setCurrentTime, setIsPlaying, isPlaying } = useTime();
@@ -353,7 +364,7 @@ function EpisodeViewerInner({
     if (!org || !dataset) return;
     const links: HTMLLinkElement[] = [];
 
-    getAdjacentEpisodesVideoInfo(org, dataset, episodeId, 2)
+    fetchAdjacentEpisodeVideos(org, dataset, episodeId, 2)
       .then((adjacentVideos) => {
         for (const ep of adjacentVideos) {
           for (const v of ep.videosInfo) {

--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -1,11 +1,13 @@
 import {
   DatasetMetadata,
+  fetchText,
   fetchParquetFile,
   formatStringWithVars,
   readParquetAsObjects,
 } from "@/utils/parquetUtils";
 import { pick } from "@/utils/pick";
 import {
+  buildDatasetAssetUrl,
   getDatasetVersionAndInfo,
   buildVersionedUrl,
 } from "@/utils/versionUtils";
@@ -20,6 +22,7 @@ import {
   buildV3EpisodesMetadataPath,
 } from "@/utils/stringFormatting";
 import { bigIntToNumber } from "@/utils/typeGuards";
+import { buildDatasetId } from "@/utils/datasetSource";
 import type { VideoInfo, AdjacentEpisodeVideos } from "@/types";
 
 const SERIES_NAME_DELIMITER = CHART_CONFIG.SERIES_NAME_DELIMITER;
@@ -296,11 +299,13 @@ export async function getEpisodeData(
   dataset: string,
   episodeId: number,
 ): Promise<EpisodeData> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   try {
-    console.time(`[perf] getDatasetVersionAndInfo`);
+    const datasetVersionStart = performance.now();
     const { version, info: rawInfo } = await getDatasetVersionAndInfo(repoId);
-    console.timeEnd(`[perf] getDatasetVersionAndInfo`);
+    console.log(
+      `[perf] getDatasetVersionAndInfo ${repoId} ${(performance.now() - datasetVersionStart).toFixed(0)}ms`,
+    );
     const info = rawInfo as unknown as DatasetMetadata;
 
     if (info.video_path === null) {
@@ -309,12 +314,14 @@ export async function getEpisodeData(
       );
     }
 
-    console.time(`[perf] getEpisodeData (${version})`);
+    const episodeDataStart = performance.now();
     const result =
       version === "v3.0"
         ? await getEpisodeDataV3(repoId, version, info, episodeId)
         : await getEpisodeDataV2(repoId, version, info, episodeId);
-    console.timeEnd(`[perf] getEpisodeData (${version})`);
+    console.log(
+      `[perf] getEpisodeData (${version}) ${repoId} episode_${episodeId} ${(performance.now() - episodeDataStart).toFixed(0)}ms`,
+    );
 
     // Extract camera resolutions from features
     const cameras: CameraInfo[] = Object.entries(rawInfo.features)
@@ -358,7 +365,7 @@ export async function getAdjacentEpisodesVideoInfo(
   currentEpisodeId: number,
   radius: number = 2,
 ): Promise<AdjacentEpisodeVideos[]> {
-  const repoId = `${org}/${dataset}`;
+  const repoId = buildDatasetId(org, dataset);
   try {
     const { version, info: rawInfo } = await getDatasetVersionAndInfo(repoId);
     const info = rawInfo as unknown as DatasetMetadata;
@@ -406,7 +413,7 @@ export async function getAdjacentEpisodesVideoInfo(
                   });
                   return {
                     filename: key,
-                    url: buildVersionedUrl(repoId, version, videoPath),
+                    url: buildDatasetAssetUrl(repoId, version, videoPath),
                   };
                 });
             }
@@ -477,7 +484,7 @@ async function getEpisodeDataV2(
             });
             return {
               filename: key,
-              url: buildVersionedUrl(repoId, version, videoPath),
+              url: buildDatasetAssetUrl(repoId, version, videoPath),
             };
           })
       : [];
@@ -570,25 +577,21 @@ async function getEpisodeDataV2(
   if (!task && allData.length > 0) {
     try {
       const tasksUrl = buildVersionedUrl(repoId, version, "meta/tasks.jsonl");
-      const tasksResponse = await fetch(tasksUrl, { cache: "no-store" });
+      const tasksText = await fetchText(tasksUrl);
+      const tasksData = tasksText
+        .split("\n")
+        .filter((line) => line.trim())
+        .map((line) => JSON.parse(line));
 
-      if (tasksResponse.ok) {
-        const tasksText = await tasksResponse.text();
-        const tasksData = tasksText
-          .split("\n")
-          .filter((line) => line.trim())
-          .map((line) => JSON.parse(line));
-
-        if (tasksData && tasksData.length > 0) {
-          const taskIndex = allData[0].task_index;
-          const taskIndexNum =
-            typeof taskIndex === "bigint" ? Number(taskIndex) : taskIndex;
-          const taskData = tasksData.find(
-            (t: Record<string, unknown>) => t.task_index === taskIndexNum,
-          );
-          if (taskData) {
-            task = taskData.task;
-          }
+      if (tasksData && tasksData.length > 0) {
+        const taskIndex = allData[0].task_index;
+        const taskIndexNum =
+          typeof taskIndex === "bigint" ? Number(taskIndex) : taskIndex;
+        const taskData = tasksData.find(
+          (t: Record<string, unknown>) => t.task_index === taskIndexNum,
+        );
+        if (taskData) {
+          task = taskData.task;
         }
       }
     } catch {
@@ -1138,11 +1141,9 @@ function extractVideoInfoV3WithSegmentation(
       bigIntToNumber(chunkIndex, 0),
       bigIntToNumber(fileIndex, 0),
     );
-    const fullUrl = buildVersionedUrl(repoId, version, videoPath);
-
     return {
       filename: videoKey,
-      url: fullUrl,
+      url: buildDatasetAssetUrl(repoId, version, videoPath),
       // Enable segmentation with timestamps from metadata
       isSegmented: true,
       segmentStart: startNum,
@@ -1554,7 +1555,7 @@ export async function loadAllEpisodeFrameInfo(
             const videoPath = `videos/${cam}/chunk-${cIdx.toString().padStart(3, "0")}/file-${fIdx.toString().padStart(3, "0")}.mp4`;
             framesByCamera[cam].push({
               episodeIndex: epIdx,
-              videoUrl: buildVersionedUrl(repoId, version, videoPath),
+              videoUrl: buildDatasetAssetUrl(repoId, version, videoPath),
               firstFrameTime: fromTs,
               lastFrameTime: Math.max(0, toTs - 0.05),
             });
@@ -1580,7 +1581,7 @@ export async function loadAllEpisodeFrameInfo(
       });
       framesByCamera[cam].push({
         episodeIndex: i,
-        videoUrl: buildVersionedUrl(repoId, version, videoPath),
+        videoUrl: buildDatasetAssetUrl(repoId, version, videoPath),
         firstFrameTime: 0,
         lastFrameTime: null,
       });

--- a/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -1,5 +1,7 @@
 import EpisodeViewer from "./episode-viewer";
 import { Suspense } from "react";
+import { buildDatasetId, getDatasetDisplayName } from "@/utils/datasetSource";
+import { fetchEpisodeDataSafe } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -10,7 +12,7 @@ export async function generateMetadata({
 }) {
   const { org, dataset, episode } = await params;
   return {
-    title: `${org}/${dataset} | episode ${episode}`,
+    title: `${getDatasetDisplayName(buildDatasetId(org, dataset))} | episode ${episode}`,
   };
 }
 
@@ -19,13 +21,19 @@ export default async function EpisodePage({
 }: {
   params: Promise<{ org: string; dataset: string; episode: string }>;
 }) {
-  // episode is like 'episode_1'
   const { org, dataset, episode } = await params;
-  // fetchData should be updated if needed to support this path pattern
   const episodeNumber = Number(episode.replace(/^episode_/, ""));
+  const initialResult = await fetchEpisodeDataSafe(org, dataset, episodeNumber);
+
   return (
     <Suspense fallback={null}>
-      <EpisodeViewer org={org} dataset={dataset} episodeId={episodeNumber} />
+      <EpisodeViewer
+        org={org}
+        dataset={dataset}
+        episodeId={episodeNumber}
+        initialData={initialResult.data ?? null}
+        initialError={initialResult.error ?? null}
+      />
     </Suspense>
   );
 }

--- a/src/app/api/local-dataset/file/__tests__/route.test.ts
+++ b/src/app/api/local-dataset/file/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { GET, HEAD } from "../route";
+
+let tempRoot: string | null = null;
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true });
+    tempRoot = null;
+  }
+});
+
+async function createDatasetDir(): Promise<string> {
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), "lerobot-local-route-"));
+  await mkdir(path.join(tempRoot, "meta"), { recursive: true });
+  await mkdir(path.join(tempRoot, "videos"), { recursive: true });
+  return tempRoot;
+}
+
+describe("local dataset file route", () => {
+  test("serves local files from inside the dataset root", async () => {
+    const root = await createDatasetDir();
+    await writeFile(path.join(root, "meta", "info.json"), '{"ok":true}');
+
+    const request = new Request(
+      `http://localhost/api/local-dataset/file?root=${encodeURIComponent(root)}&path=${encodeURIComponent("meta/info.json")}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.text()).toBe('{"ok":true}');
+  });
+
+  test("blocks path traversal outside the dataset root", async () => {
+    const root = await createDatasetDir();
+
+    const request = new Request(
+      `http://localhost/api/local-dataset/file?root=${encodeURIComponent(root)}&path=${encodeURIComponent("../secret.txt")}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("outside the dataset directory");
+  });
+
+  test("supports ranged HEAD requests for local video files", async () => {
+    const root = await createDatasetDir();
+    await writeFile(
+      path.join(root, "videos", "episode.mp4"),
+      Buffer.from("0123456789"),
+    );
+
+    const request = new Request(
+      `http://localhost/api/local-dataset/file?root=${encodeURIComponent(root)}&path=${encodeURIComponent("videos/episode.mp4")}`,
+      {
+        method: "HEAD",
+        headers: { range: "bytes=2-5" },
+      },
+    );
+    const response = await HEAD(request);
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(response.headers.get("content-length")).toBe("4");
+  });
+});

--- a/src/app/api/local-dataset/file/route.ts
+++ b/src/app/api/local-dataset/file/route.ts
@@ -1,0 +1,192 @@
+import { createReadStream, promises as fs } from "node:fs";
+import path from "node:path";
+
+function createWebStream(filePath: string, start?: number, end?: number) {
+  const nodeStream = createReadStream(filePath, { start, end });
+  let closed = false;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const close = () => {
+        if (closed) return;
+        try {
+          controller.close();
+        } catch {
+          // The response may have already closed the controller after abort.
+        } finally {
+          closed = true;
+        }
+      };
+
+      const fail = (error: unknown) => {
+        if (closed) return;
+        try {
+          controller.error(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        } catch {
+          // Ignore late errors after the consumer has already closed.
+        } finally {
+          closed = true;
+        }
+      };
+
+      nodeStream.on("data", (chunk: string | Buffer) => {
+        if (closed) return;
+        try {
+          const chunkBytes =
+            typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+          controller.enqueue(new Uint8Array(chunkBytes));
+        } catch {
+          closed = true;
+          nodeStream.destroy();
+        }
+      });
+
+      nodeStream.once("end", close);
+      nodeStream.once("close", () => {
+        closed = true;
+      });
+      nodeStream.once("error", fail);
+    },
+    cancel() {
+      closed = true;
+      nodeStream.destroy();
+    },
+  });
+}
+
+function expandHomeDir(inputPath: string): string {
+  if (inputPath === "~") {
+    return process.env.HOME ?? inputPath;
+  }
+  if (inputPath.startsWith("~/")) {
+    return path.join(process.env.HOME ?? "~", inputPath.slice(2));
+  }
+  return inputPath;
+}
+
+function resolveRoot(root: string): string {
+  const withoutFileProtocol = root.replace(/^file:\/\//, "");
+  return path.resolve(expandHomeDir(withoutFileProtocol));
+}
+
+function resolveDatasetFile(root: string, relativePath: string): string {
+  const normalizedRoot = resolveRoot(root);
+  const targetPath = path.resolve(normalizedRoot, relativePath);
+  const relative = path.relative(normalizedRoot, targetPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Requested path is outside the dataset directory");
+  }
+  return targetPath;
+}
+
+function getContentType(filePath: string): string {
+  switch (path.extname(filePath).toLowerCase()) {
+    case ".mp4":
+      return "video/mp4";
+    case ".json":
+      return "application/json";
+    case ".jsonl":
+      return "application/x-ndjson";
+    case ".parquet":
+      return "application/octet-stream";
+    case ".webm":
+      return "video/webm";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+async function buildResponse(
+  request: Request,
+  includeBody: boolean,
+): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const root = searchParams.get("root");
+  const relativePath = searchParams.get("path");
+
+  if (!root || !relativePath) {
+    return new Response("Missing root or path parameter", { status: 400 });
+  }
+
+  let filePath: string;
+  try {
+    filePath = resolveDatasetFile(root, relativePath);
+  } catch (error) {
+    return new Response(
+      error instanceof Error ? error.message : "Invalid path",
+      {
+        status: 400,
+      },
+    );
+  }
+
+  let stats;
+  try {
+    stats = await fs.stat(filePath);
+  } catch {
+    return new Response("File not found", { status: 404 });
+  }
+
+  if (!stats.isFile()) {
+    return new Response("Not a file", { status: 400 });
+  }
+
+  const headers = new Headers({
+    "accept-ranges": "bytes",
+    "content-type": getContentType(filePath),
+    "content-length": String(stats.size),
+    "cache-control": "no-store",
+  });
+
+  const range = request.headers.get("range");
+  if (!range) {
+    if (!includeBody) {
+      return new Response(null, { status: 200, headers });
+    }
+
+    const stream = createWebStream(filePath);
+    return new Response(stream, { status: 200, headers });
+  }
+
+  const match = /bytes=(\d*)-(\d*)/.exec(range);
+  if (!match) {
+    return new Response("Invalid range", { status: 416 });
+  }
+
+  const start = match[1] ? Number.parseInt(match[1], 10) : 0;
+  const end = match[2] ? Number.parseInt(match[2], 10) : stats.size - 1;
+
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start > end ||
+    end >= stats.size
+  ) {
+    return new Response("Invalid range", { status: 416 });
+  }
+
+  headers.set("content-length", String(end - start + 1));
+  headers.set("content-range", `bytes ${start}-${end}/${stats.size}`);
+
+  if (!includeBody) {
+    return new Response(null, { status: 206, headers });
+  }
+
+  const stream = createWebStream(filePath, start, end);
+  return new Response(stream, { status: 206, headers });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return buildResponse(request, true);
+}
+
+export async function HEAD(request: Request): Promise<Response> {
+  return buildResponse(request, false);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,10 @@ import { useEffect, useRef, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
+import {
+  buildDatasetRoute,
+  isLikelyLocalDatasetInput,
+} from "@/utils/datasetSource";
 
 declare global {
   interface Window {
@@ -33,6 +37,7 @@ const EXAMPLE_DATASETS = [
 function HomeInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [isVideoReady, setIsVideoReady] = useState(false);
 
   // Handle redirects with useEffect instead of direct redirect
   useEffect(() => {
@@ -43,7 +48,7 @@ function HomeInner() {
           .map((x) => parseInt(x.trim(), 10))
           .filter((x) => !isNaN(x))[0] ?? 0;
 
-      router.push(`/${process.env.REPO_ID}/episode_${episodeN}`);
+      router.push(buildDatasetRoute(process.env.REPO_ID, episodeN));
       return;
     }
 
@@ -74,15 +79,15 @@ function HomeInner() {
   const playerRef = useRef<{ destroy?: () => void } | null>(null);
 
   useEffect(() => {
-    // Load YouTube IFrame API if not already present
-    if (!window.YT) {
-      const tag = document.createElement("script");
-      tag.src = "https://www.youtube.com/iframe_api";
-      document.body.appendChild(tag);
-    }
-    let interval: NodeJS.Timeout;
-    window.onYouTubeIframeAPIReady = () => {
-      if (!window.YT) return;
+    setIsVideoReady(false);
+
+    const initializePlayer = () => {
+      if (!window.YT?.Player) return;
+
+      if (playerRef.current?.destroy) {
+        playerRef.current.destroy();
+      }
+
       playerRef.current = new window.YT.Player("yt-bg-player", {
         videoId: "Er8SPJsIYr0",
         playerVars: {
@@ -108,6 +113,7 @@ function HomeInner() {
           }) => {
             event.target.playVideo();
             event.target.mute();
+            setIsVideoReady(true);
             interval = setInterval(() => {
               const t = event.target.getCurrentTime();
               if (t >= 60) {
@@ -118,8 +124,27 @@ function HomeInner() {
         },
       });
     };
+
+    // Load YouTube IFrame API if not already present
+    if (!window.YT) {
+      const tag = document.createElement("script");
+      tag.src = "https://www.youtube.com/iframe_api";
+      tag.onerror = () => {
+        setIsVideoReady(false);
+      };
+      document.body.appendChild(tag);
+    }
+    let interval: NodeJS.Timeout;
+
+    if (window.YT?.Player) {
+      initializePlayer();
+    } else {
+      window.onYouTubeIframeAPIReady = initializePlayer;
+    }
+
     return () => {
       if (interval) clearInterval(interval);
+      setIsVideoReady(false);
       if (playerRef.current && playerRef.current.destroy)
         playerRef.current.destroy();
     };
@@ -135,6 +160,13 @@ function HomeInner() {
 
   useEffect(() => {
     if (!query.trim()) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      setIsLoading(false);
+      setHasFetched(false);
+      return;
+    }
+    if (isLikelyLocalDatasetInput(query)) {
       setSuggestions([]);
       setShowSuggestions(false);
       setIsLoading(false);
@@ -182,7 +214,7 @@ function HomeInner() {
   const navigate = useCallback(
     (value: string) => {
       setShowSuggestions(false);
-      router.push(value);
+      router.push(buildDatasetRoute(value));
     },
     [router],
   );
@@ -213,7 +245,11 @@ function HomeInner() {
   return (
     <div className="relative h-screen w-screen overflow-hidden">
       {/* YouTube Video Background */}
-      <div className="video-background">
+      <div
+        className={`video-background transition-opacity duration-700 ${
+          isVideoReady ? "opacity-100" : "opacity-0"
+        }`}
+      >
         <div id="yt-bg-player" />
       </div>
 
@@ -233,110 +269,146 @@ function HomeInner() {
 
         {/* Subtitle */}
         <p className="text-white/55 text-base md:text-lg mb-8 max-w-md">
-          Explore and visualize robot learning datasets from Hugging Face
+          Explore robot learning datasets from Hugging Face or an absolute local
+          path
         </p>
 
         {/* Search form */}
-        <form onSubmit={handleSubmit} className="flex gap-2 justify-center">
-          <div ref={containerRef} className="relative">
-            {/* Search icon */}
-            <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 pointer-events-none"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col items-center gap-3"
+        >
+          <div className="flex gap-2 justify-center">
+            <div ref={containerRef} className="relative">
+              {/* Search icon */}
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 pointer-events-none"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+                />
+              </svg>
+
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onFocus={() => query.trim() && setShowSuggestions(true)}
+                placeholder="Enter HF dataset id or local path"
+                className="pl-10 pr-4 py-2.5 rounded-md text-base text-white bg-white/10 backdrop-blur-sm border border-white/30 focus:outline-none focus:border-sky-400 focus:bg-white/15 w-[380px] shadow-md placeholder:text-white/40 transition-colors"
+                autoComplete="off"
               />
-            </svg>
 
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onFocus={() => query.trim() && setShowSuggestions(true)}
-              placeholder="Enter dataset id (e.g. lerobot/pusht)"
-              className="pl-10 pr-4 py-2.5 rounded-md text-base text-white bg-white/10 backdrop-blur-sm border border-white/30 focus:outline-none focus:border-sky-400 focus:bg-white/15 w-[380px] shadow-md placeholder:text-white/40 transition-colors"
-              autoComplete="off"
-            />
-
-            {/* Suggestions dropdown */}
-            {showSuggestions && (
-              <ul className="absolute left-0 right-0 top-full mt-1 rounded-md bg-slate-900/95 backdrop-blur-sm border border-white/10 shadow-xl overflow-hidden z-50 max-h-64 overflow-y-auto">
-                {isLoading ? (
-                  <li className="flex items-center gap-2.5 px-4 py-3 text-sm text-white/50">
-                    <svg
-                      className="animate-spin w-4 h-4 shrink-0"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8v8H4z"
-                      />
-                    </svg>
-                    Searching…
-                  </li>
-                ) : suggestions.length > 0 ? (
-                  suggestions.map((id, i) => (
-                    <li key={id}>
-                      <button
-                        type="button"
-                        className={`w-full text-left px-4 py-2.5 text-sm transition-colors ${
-                          i === activeIndex
-                            ? "bg-sky-600 text-white"
-                            : "text-slate-200 hover:bg-slate-700"
-                        }`}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          navigate(id);
-                        }}
-                        onMouseEnter={() => setActiveIndex(i)}
+              {/* Suggestions dropdown */}
+              {showSuggestions && (
+                <ul className="absolute left-0 right-0 top-full mt-1 rounded-md bg-slate-900/95 backdrop-blur-sm border border-white/10 shadow-xl overflow-hidden z-50 max-h-64 overflow-y-auto">
+                  {isLoading ? (
+                    <li className="flex items-center gap-2.5 px-4 py-3 text-sm text-white/50">
+                      <svg
+                        className="animate-spin w-4 h-4 shrink-0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
                       >
-                        {id}
-                      </button>
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8v8H4z"
+                        />
+                      </svg>
+                      Searching…
                     </li>
-                  ))
-                ) : (
-                  hasFetched && (
-                    <li className="px-4 py-3 text-sm text-white/40">
-                      No datasets found
-                    </li>
-                  )
-                )}
-              </ul>
-            )}
-          </div>
+                  ) : suggestions.length > 0 ? (
+                    suggestions.map((id, i) => (
+                      <li key={id}>
+                        <button
+                          type="button"
+                          className={`w-full text-left px-4 py-2.5 text-sm transition-colors ${
+                            i === activeIndex
+                              ? "bg-sky-600 text-white"
+                              : "text-slate-200 hover:bg-slate-700"
+                          }`}
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            navigate(id);
+                          }}
+                          onMouseEnter={() => setActiveIndex(i)}
+                        >
+                          {id}
+                        </button>
+                      </li>
+                    ))
+                  ) : (
+                    hasFetched && (
+                      <li className="px-4 py-3 text-sm text-white/40">
+                        No datasets found
+                      </li>
+                    )
+                  )}
+                </ul>
+              )}
+            </div>
 
-          <button
-            type="submit"
-            className="px-5 py-2.5 rounded-md bg-sky-500 text-white font-semibold text-base hover:bg-sky-400 active:scale-95 transition-all shadow-md flex items-center gap-2"
-          >
-            Go
-            <kbd className="text-xs font-mono bg-white/20 rounded px-1 py-0.5 leading-tight">
-              ↵
-            </kbd>
-          </button>
+            <button
+              type="submit"
+              className="px-5 py-2.5 rounded-md bg-sky-500 text-white font-semibold text-base hover:bg-sky-400 active:scale-95 transition-all shadow-md flex items-center gap-2"
+            >
+              Go
+              <kbd className="text-xs font-mono bg-white/20 rounded px-1 py-0.5 leading-tight">
+                ↵
+              </kbd>
+            </button>
+          </div>
         </form>
+
+        <div className="mt-5 w-full max-w-2xl grid gap-3 md:grid-cols-2 text-left">
+          <div className="rounded-xl border border-white/10 bg-white/8 px-4 py-4 backdrop-blur-sm">
+            <p className="text-xs uppercase tracking-[0.2em] text-white/40 mb-2">
+              Remote
+            </p>
+            <p className="text-sm text-white/80">
+              Paste a Hugging Face dataset id such as{" "}
+              <span className="font-mono text-sky-200">lerobot/pusht</span>.
+            </p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/8 px-4 py-4 backdrop-blur-sm">
+            <p className="text-xs uppercase tracking-[0.2em] text-white/40 mb-2">
+              Local Path
+            </p>
+            <p className="text-sm text-white/80">
+              Paste an absolute directory path like{" "}
+              <span className="font-mono text-sky-200">
+                /data/lerobot/my_dataset
+              </span>
+              .
+            </p>
+          </div>
+        </div>
 
         {/* Example Datasets */}
         <div className="mt-8">
+          <p className="text-white/50 text-sm mb-4 max-w-xl">
+            Supports Hugging Face datasets like{" "}
+            <span className="font-mono">lerobot/pusht</span> and local absolute
+            paths like{" "}
+            <span className="font-mono">/data/lerobot/my_dataset</span>.
+          </p>
           <p className="text-white/40 text-xs uppercase tracking-widest mb-3 font-medium">
             Example Datasets
           </p>

--- a/src/utils/__tests__/datasetSource.test.ts
+++ b/src/utils/__tests__/datasetSource.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildDatasetId,
+  buildDatasetRoute,
+  buildLocalDatasetAssetUrl,
+  decodeLocalDatasetPath,
+  encodeLocalDatasetPath,
+  getDatasetDisplayName,
+  getLocalDatasetPath,
+  isLikelyLocalDatasetInput,
+  isLocalDatasetId,
+  parseLocalDatasetUrl,
+} from "@/utils/datasetSource";
+
+describe("datasetSource local path handling", () => {
+  test("detects local dataset path inputs", () => {
+    expect(isLikelyLocalDatasetInput("/data/aloha")).toBe(true);
+    expect(isLikelyLocalDatasetInput("~/data/aloha")).toBe(true);
+    expect(isLikelyLocalDatasetInput("file:///tmp/aloha")).toBe(true);
+    expect(isLikelyLocalDatasetInput("./data/aloha")).toBe(false);
+    expect(isLikelyLocalDatasetInput("../data/aloha")).toBe(false);
+    expect(isLikelyLocalDatasetInput("lerobot/aloha_static_cups_open")).toBe(
+      false,
+    );
+  });
+
+  test("encodes and decodes local dataset paths for routing", () => {
+    const encoded = encodeLocalDatasetPath("~/data/aloha_static_cups_open/");
+    expect(encoded).toBe("~%2Fdata%2Faloha_static_cups_open");
+    expect(decodeLocalDatasetPath(encoded)).toBe(
+      "~/data/aloha_static_cups_open",
+    );
+  });
+
+  test("builds local dataset routes and ids", () => {
+    const route = buildDatasetRoute("/tmp/aloha_static_cups_open", 7);
+    expect(route).toBe("/local/%2Ftmp%2Faloha_static_cups_open/episode_7");
+
+    const datasetId = buildDatasetId(
+      "local",
+      "%2Ftmp%2Faloha_static_cups_open",
+    );
+    expect(datasetId).toBe("local:/tmp/aloha_static_cups_open");
+    expect(isLocalDatasetId(datasetId)).toBe(true);
+    expect(getLocalDatasetPath(datasetId)).toBe("/tmp/aloha_static_cups_open");
+    expect(getDatasetDisplayName(datasetId)).toBe(
+      "/tmp/aloha_static_cups_open",
+    );
+  });
+
+  test("builds and parses internal local asset urls", () => {
+    const url = buildLocalDatasetAssetUrl("/tmp/aloha", "meta/info.json");
+    expect(url).toBe(
+      "/api/local-dataset/file?root=%2Ftmp%2Faloha&path=meta%2Finfo.json",
+    );
+
+    const parsed = parseLocalDatasetUrl(
+      "local://dataset-file?root=%2Ftmp%2Faloha&path=videos%2Ftop.mp4",
+    );
+    expect(parsed).toEqual({
+      root: "/tmp/aloha",
+      path: "videos/top.mp4",
+    });
+  });
+});

--- a/src/utils/__tests__/versionUtils.test.ts
+++ b/src/utils/__tests__/versionUtils.test.ts
@@ -55,6 +55,17 @@ describe("buildVersionedUrl", () => {
       "https://huggingface.co/datasets/myorg/mydataset/resolve/main/meta/info.json",
     );
   });
+
+  test("builds local dataset urls for server-side asset access", () => {
+    const url = buildVersionedUrl(
+      "local:/tmp/aloha_static_cups_open",
+      "v3.0",
+      "meta/info.json",
+    );
+    expect(url).toBe(
+      "local://dataset-file?root=%2Ftmp%2Faloha_static_cups_open&path=meta%2Finfo.json",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/datasetSource.ts
+++ b/src/utils/datasetSource.ts
@@ -1,0 +1,101 @@
+const LOCAL_DATASET_ORG = "local";
+const LOCAL_REPO_PREFIX = "local:";
+const LOCAL_URL_PROTOCOL = "local://dataset-file";
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/[\\/]+$/, "");
+}
+
+export function isLikelyLocalDatasetInput(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("~/") ||
+    trimmed.startsWith("file://") ||
+    /^[A-Za-z]:[\\/]/.test(trimmed)
+  );
+}
+
+export function encodeLocalDatasetPath(localPath: string): string {
+  return encodeURIComponent(stripTrailingSlash(localPath.trim()));
+}
+
+export function decodeLocalDatasetPath(encodedPath: string): string {
+  return decodeURIComponent(encodedPath);
+}
+
+export function buildDatasetRoute(input: string, episode = 0): string {
+  const trimmed = input.trim();
+  if (isLikelyLocalDatasetInput(trimmed)) {
+    return `/${LOCAL_DATASET_ORG}/${encodeLocalDatasetPath(trimmed)}/episode_${episode}`;
+  }
+
+  const normalized = trimmed.replace(
+    /^https?:\/\/huggingface\.co\/datasets\//,
+    "",
+  );
+  return `/${normalized}/episode_${episode}`;
+}
+
+export function buildDatasetId(org: string, dataset: string): string {
+  if (org === LOCAL_DATASET_ORG) {
+    return `${LOCAL_REPO_PREFIX}${decodeLocalDatasetPath(dataset)}`;
+  }
+
+  return `${org}/${dataset}`;
+}
+
+export function isLocalDatasetId(datasetId: string): boolean {
+  return datasetId.startsWith(LOCAL_REPO_PREFIX);
+}
+
+export function getLocalDatasetPath(datasetId: string): string {
+  return datasetId.slice(LOCAL_REPO_PREFIX.length);
+}
+
+export function buildLocalDatasetUrl(
+  path: string,
+  relativePath: string,
+): string {
+  const url = new URL(LOCAL_URL_PROTOCOL);
+  url.searchParams.set("root", path);
+  url.searchParams.set("path", relativePath);
+  return url.toString();
+}
+
+export function parseLocalDatasetUrl(url: string): {
+  root: string;
+  path: string;
+} | null {
+  if (!url.startsWith(LOCAL_URL_PROTOCOL)) {
+    return null;
+  }
+
+  const parsed = new URL(url);
+  const root = parsed.searchParams.get("root");
+  const path = parsed.searchParams.get("path");
+  if (!root || !path) {
+    return null;
+  }
+
+  return { root, path };
+}
+
+export function getDatasetDisplayName(datasetId: string): string {
+  return isLocalDatasetId(datasetId)
+    ? getLocalDatasetPath(datasetId)
+    : datasetId;
+}
+
+export function buildLocalDatasetAssetUrl(
+  localDatasetPath: string,
+  relativePath: string,
+): string {
+  const params = new URLSearchParams({
+    root: localDatasetPath,
+    path: relativePath,
+  });
+  return `/api/local-dataset/file?${params.toString()}`;
+}
+
+export { LOCAL_DATASET_ORG };

--- a/src/utils/parquetUtils.ts
+++ b/src/utils/parquetUtils.ts
@@ -5,6 +5,7 @@ import {
   parquetReadObjects,
   type AsyncBuffer,
 } from "hyparquet";
+import { parseLocalDatasetUrl } from "@/utils/datasetSource";
 
 export interface DatasetMetadata {
   codebase_version: string;
@@ -30,7 +31,73 @@ export interface DatasetMetadata {
   >;
 }
 
+function expandHomeDir(inputPath: string): string {
+  if (inputPath === "~") {
+    return process.env.HOME ?? inputPath;
+  }
+  if (inputPath.startsWith("~/")) {
+    return `${process.env.HOME ?? "~"}/${inputPath.slice(2)}`;
+  }
+  return inputPath;
+}
+
+async function runtimeImport<T>(specifier: string): Promise<T> {
+  const importer = Function("moduleName", "return import(moduleName)") as (
+    moduleName: string,
+  ) => Promise<unknown>;
+  return (await importer(specifier)) as T;
+}
+
+async function getServerPathModule(): Promise<typeof import("path")> {
+  return runtimeImport<typeof import("path")>("path");
+}
+
+async function getServerFsPromises(): Promise<typeof import("fs/promises")> {
+  return runtimeImport<typeof import("fs/promises")>("fs/promises");
+}
+
+async function resolveLocalDatasetFile(
+  root: string,
+  relativePath: string,
+): Promise<string> {
+  const path = await getServerPathModule();
+  const normalizedRoot = path.resolve(
+    expandHomeDir(root.replace(/^file:\/\//, "")),
+  );
+  const targetPath = path.resolve(normalizedRoot, relativePath);
+  const relative = path.relative(normalizedRoot, targetPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Requested path is outside the dataset directory");
+  }
+  return targetPath;
+}
+
+async function readLocalDatasetFile(url: string): Promise<ArrayBuffer> {
+  const parsed = parseLocalDatasetUrl(url);
+  if (!parsed) {
+    throw new Error(`Invalid local dataset URL: ${url}`);
+  }
+
+  const filePath = await resolveLocalDatasetFile(parsed.root, parsed.path);
+  const fs = await getServerFsPromises();
+  const file = await fs.readFile(filePath);
+  return file.buffer.slice(
+    file.byteOffset,
+    file.byteOffset + file.byteLength,
+  ) as ArrayBuffer;
+}
+
 export async function fetchJson<T>(url: string): Promise<T> {
+  const localDataset = parseLocalDatasetUrl(url);
+  if (localDataset) {
+    const fs = await getServerFsPromises();
+    const raw = await fs.readFile(
+      await resolveLocalDatasetFile(localDataset.root, localDataset.path),
+      "utf8",
+    );
+    return JSON.parse(raw) as T;
+  }
+
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) {
     throw new Error(
@@ -53,6 +120,11 @@ type ParquetFile = ArrayBuffer | AsyncBuffer;
 const parquetFileCache = new Map<string, AsyncBuffer>();
 
 export async function fetchParquetFile(url: string): Promise<ParquetFile> {
+  const localDataset = parseLocalDatasetUrl(url);
+  if (localDataset) {
+    return readLocalDatasetFile(url);
+  }
+
   const cached = parquetFileCache.get(url);
   if (cached) return cached;
 
@@ -99,6 +171,25 @@ export async function readParquetAsObjects(
     rowStart: options?.rowStart,
     rowEnd: options?.rowEnd,
   }) as Promise<Record<string, unknown>[]>;
+}
+
+export async function fetchText(url: string): Promise<string> {
+  const localDataset = parseLocalDatasetUrl(url);
+  if (localDataset) {
+    const fs = await getServerFsPromises();
+    return fs.readFile(
+      await resolveLocalDatasetFile(localDataset.root, localDataset.path),
+      "utf8",
+    );
+  }
+
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch text ${url}: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.text();
 }
 
 // Convert a 2D array to a CSV string

--- a/src/utils/versionUtils.ts
+++ b/src/utils/versionUtils.ts
@@ -2,6 +2,13 @@
  * Utility functions for checking dataset version compatibility
  */
 
+import {
+  buildLocalDatasetAssetUrl,
+  buildLocalDatasetUrl,
+  getLocalDatasetPath,
+  isLocalDatasetId,
+} from "@/utils/datasetSource";
+
 const DATASET_URL =
   process.env.DATASET_URL || "https://huggingface.co/datasets";
 
@@ -58,6 +65,44 @@ function pruneDatasetInfoCache(now: number) {
   }
 }
 
+async function getLocalDatasetInfo(repoId: string): Promise<DatasetInfo> {
+  const localDatasetPath = getLocalDatasetPath(repoId);
+
+  if (typeof window !== "undefined") {
+    const response = await fetch(
+      buildLocalDatasetAssetUrl(localDatasetPath, "meta/info.json"),
+      {
+        method: "GET",
+        cache: "no-store",
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch local dataset info: ${response.status}`);
+    }
+
+    return (await response.json()) as DatasetInfo;
+  }
+
+  const runtimeImport = Function("specifier", "return import(specifier)") as (
+    specifier: string,
+  ) => Promise<unknown>;
+  const fs = (await runtimeImport(
+    "fs/promises",
+  )) as typeof import("fs/promises");
+  const path = (await runtimeImport("path")) as typeof import("path");
+  const home = process.env.HOME ?? "~";
+  const expandedPath =
+    localDatasetPath === "~"
+      ? home
+      : localDatasetPath.startsWith("~/")
+        ? path.join(home, localDatasetPath.slice(2))
+        : localDatasetPath;
+  const infoPath = path.join(path.resolve(expandedPath), "meta", "info.json");
+  const raw = await fs.readFile(infoPath, "utf8");
+  return JSON.parse(raw) as DatasetInfo;
+}
+
 export async function getDatasetInfo(repoId: string): Promise<DatasetInfo> {
   const now = Date.now();
   pruneDatasetInfoCache(now);
@@ -73,6 +118,23 @@ export async function getDatasetInfo(repoId: string): Promise<DatasetInfo> {
   console.log(`[perf] getDatasetInfo cache MISS for ${repoId} — fetching`);
 
   try {
+    if (isLocalDatasetId(repoId)) {
+      const data = await getLocalDatasetInfo(repoId);
+
+      if (!data.features) {
+        throw new Error(
+          "Dataset info.json does not have the expected features structure",
+        );
+      }
+
+      datasetInfoCache.set(repoId, {
+        data: data as DatasetInfo,
+        expiry: Date.now() + CACHE_TTL_MS,
+      });
+      pruneDatasetInfoCache(Date.now());
+      return data as DatasetInfo;
+    }
+
     const testUrl = `${DATASET_URL}/${repoId}/resolve/main/meta/info.json`;
 
     const controller = new AbortController();
@@ -149,5 +211,21 @@ export function buildVersionedUrl(
   version: string,
   path: string,
 ): string {
+  if (isLocalDatasetId(repoId)) {
+    return buildLocalDatasetUrl(getLocalDatasetPath(repoId), path);
+  }
+
   return `${DATASET_URL}/${repoId}/resolve/main/${path}`;
+}
+
+export function buildDatasetAssetUrl(
+  repoId: string,
+  version: string,
+  path: string,
+): string {
+  if (isLocalDatasetId(repoId)) {
+    return buildLocalDatasetAssetUrl(getLocalDatasetPath(repoId), path);
+  }
+
+  return buildVersionedUrl(repoId, version, path);
 }


### PR DESCRIPTION
## Summary

This PR adds support for opening local LeRobot datasets directly from the app, in addition to datasets hosted on the Hugging Face Hub.

Users can now paste a local dataset path on the home page and open it with the same episode viewer flow used for remote datasets.

## What changed

- add local dataset path detection and route building
- add a local file API route for serving dataset assets from disk
- support reading local `meta/info.json`, parquet files, text metadata, and videos
- make dataset/version utilities work with both Hub datasets and local datasets
- move initial episode loading behind a server boundary so local datasets work correctly in the episode page
- update episode-level data fetching for local dataset ids and asset URLs
- add homepage guidance for remote ids vs local paths
- add tests for local dataset path utilities, local file serving, and local dataset URL handling
- update README with local dataset usage notes

## Why

The current app works well for Hub-hosted datasets, but it is difficult to inspect datasets that only exist locally or are still being prepared before upload. This change makes local exploration possible without changing the existing remote dataset flow.

## Notes

- local paths are expected to point to a standard LeRobot dataset directory
- the server process must be able to read the target directory
- local file access is constrained to the selected dataset root to avoid path traversal outside the dataset directory

## Validation

Validated with:

- `bun run format`
- `bun run type-check`
- `bun run lint`
- `bun test`

Also verified manually with:

- local dataset loading from disk
- remote dataset loading regression check
- homepage local-path flow

Related to #12