### PR TITLE
Feat local mode and landing page

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -15,13 +15,13 @@ jobs:
   sync-to-hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           lfs: true
           ref: main
       - name: Sync to HF Space
-        uses: huggingface/hub-sync@4d340790b2a7cc86e598dce1c29a0c7c6adf3d62  # main
+        uses: huggingface/hub-sync@4d340790b2a7cc86e598dce1c29a0c7c6adf3d62 # main
         with:
           github_repo_id: huggingface/lerobot-dataset-visualizer
           huggingface_repo_id: lerobot/visualize_dataset

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN bun install --frozen-lockfile
 # Copy the rest of the application
 COPY . .
 
+# Set LOCAL_DATASET_PATH so NEXT_PUBLIC_LOCAL_MODE is baked into the build
+ENV LOCAL_DATASET_PATH=/data
+
 # Build the application
 RUN bun run build
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ bun run format
 ### Environment Variables
 
 - `DATASET_URL`: (optional) Base URL for dataset hosting (defaults to HuggingFace Datasets).
+- `LOCAL_DATASET_PATH`: (optional) Path to a local dataset directory. Enables local mode.
+
+### Local Dataset Mode
+
+To run the dev server with a local dataset:
+
+```bash
+LOCAL_DATASET_PATH=../gb-lerobot/datasets bun dev
+```
+
+This sets `NEXT_PUBLIC_LOCAL_MODE` at build time so the app serves data from the local filesystem instead of HuggingFace.
 
 ## Docker Deployment
 
@@ -103,17 +114,35 @@ This application can be deployed using Docker with bun for optimal performance a
 
 ### Build the Docker image
 
+The Dockerfile sets `LOCAL_DATASET_PATH=/data` at build time so that `NEXT_PUBLIC_LOCAL_MODE` is baked into the Next.js build. This means the image supports local datasets out of the box.
+
 ```bash
 docker build -t lerobot-visualizer .
 ```
 
-### Run the container
+### Run the container (remote HuggingFace datasets)
 
 ```bash
 docker run -p 7860:7860 lerobot-visualizer
 ```
 
 The application will be available at [http://localhost:7860](http://localhost:7860).
+
+### Run with local datasets
+
+The Docker image is pre-configured for local dataset mode. Mount your local dataset directory into the container at `/data`:
+
+```bash
+docker run -p 7860:7860 -v /absolute/path/to/your/datasets:/data lerobot-visualizer
+```
+
+For example, if your datasets are at `../gb-lerobot/datasets` relative to the project:
+
+```bash
+docker run -p 7860:7860 -v $(realpath ../gb-lerobot/datasets):/data lerobot-visualizer
+```
+
+> **Note:** The `-v` flag mounts a host directory into the container. The path before `:` must be an absolute path on your host machine. The path after `:` must be `/data` to match the container's `LOCAL_DATASET_PATH`.
 
 ### Run with custom environment variables
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bun run format
 To run the dev server with a local dataset:
 
 ```bash
-LOCAL_DATASET_PATH=../gb-lerobot/datasets bun dev
+LOCAL_DATASET_PATH=/path/to/your/datasets bun dev
 ```
 
 This sets `NEXT_PUBLIC_LOCAL_MODE` at build time so the app serves data from the local filesystem instead of HuggingFace.
@@ -136,10 +136,10 @@ The Docker image is pre-configured for local dataset mode. Mount your local data
 docker run -p 7860:7860 -v /absolute/path/to/your/datasets:/data lerobot-visualizer
 ```
 
-For example, if your datasets are at `../gb-lerobot/datasets` relative to the project:
+For example, if your datasets are at `../my-datasets` relative to the project:
 
 ```bash
-docker run -p 7860:7860 -v $(realpath ../gb-lerobot/datasets):/data lerobot-visualizer
+docker run -p 7860:7860 -v $(realpath ../my-datasets):/data lerobot-visualizer
 ```
 
 > **Note:** The `-v` flag mounts a host directory into the container. The path before `:` must be an absolute path on your host machine. The path after `:` must be `/data` to match the container's `LOCAL_DATASET_PATH`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const nextConfig: NextConfig = {
   },
   transpilePackages: ["three"],
   generateBuildId: () => packageJson.version,
+  env: {
+    NEXT_PUBLIC_LOCAL_MODE: process.env.LOCAL_DATASET_PATH ? "1" : "",
+  },
 };
 
 export default nextConfig;

--- a/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -20,7 +20,8 @@ export default async function EpisodePage({
   params: Promise<{ org: string; dataset: string; episode: string }>;
 }) {
   // episode is like 'episode_1'
-  const { org, dataset, episode } = await params;
+  const { org, dataset: rawDataset, episode } = await params;
+  const dataset = decodeURIComponent(rawDataset);
   // fetchData should be updated if needed to support this path pattern
   const episodeNumber = Number(episode.replace(/^episode_/, ""));
   return (

--- a/src/app/[org]/[dataset]/page.tsx
+++ b/src/app/[org]/[dataset]/page.tsx
@@ -11,5 +11,5 @@ export default async function DatasetRootPage({
       .map((x) => parseInt(x.trim(), 10))
       .filter((x) => !isNaN(x))[0] ?? 0;
 
-  redirect(`/${org}/${dataset}/episode_${episodeN}`);
+  redirect(`/${org}/${encodeURIComponent(dataset)}/episode_${episodeN}`);
 }

--- a/src/app/[org]/[dataset]/page.tsx
+++ b/src/app/[org]/[dataset]/page.tsx
@@ -5,7 +5,8 @@ export default async function DatasetRootPage({
 }: {
   params: Promise<{ org: string; dataset: string }>;
 }) {
-  const { org, dataset } = await params;
+  const { org, dataset: rawDataset } = await params;
+  const dataset = decodeURIComponent(rawDataset);
   const episodeN =
     process.env.EPISODES?.split(/\s+/)
       .map((x) => parseInt(x.trim(), 10))

--- a/src/app/api/local-dataset/[...path]/route.ts
+++ b/src/app/api/local-dataset/[...path]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { join, resolve, sep } from "path";
+
+const LOCAL_DATASET_PATH = process.env.LOCAL_DATASET_PATH;
+
+const EXT_CONTENT_TYPE: Record<string, string> = {
+  json: "application/json",
+  jsonl: "application/x-ndjson",
+  parquet: "application/octet-stream",
+  mp4: "video/mp4",
+};
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<NextResponse> {
+  if (!LOCAL_DATASET_PATH) {
+    return NextResponse.json(
+      { error: "Local dataset mode not enabled" },
+      { status: 404 },
+    );
+  }
+
+  const pathSegments = (await params).path;
+
+  // Validate: all segments must be safe (no ".." or absolute paths)
+  if (pathSegments.some((s) => s === ".." || s.startsWith("/"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const base = resolve(process.cwd(), LOCAL_DATASET_PATH);
+  const target = resolve(join(base, ...pathSegments));
+
+  // Secondary path-traversal guard
+  const normalizedBase = base.endsWith(sep) ? base : base + sep;
+  if (!target.startsWith(normalizedBase) && target !== base) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = await readFile(target);
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const ext = target.split(".").pop()?.toLowerCase() ?? "";
+  const contentType = EXT_CONTENT_TYPE[ext] ?? "application/octet-stream";
+
+  // Support HTTP range requests so browsers can seek in video files
+  const rangeHeader = request.headers.get("range");
+  if (contentType === "video/mp4" && rangeHeader) {
+    const total = buffer.length;
+    const match = /bytes=(\d+)-(\d*)/.exec(rangeHeader);
+    if (match) {
+      const start = parseInt(match[1], 10);
+      const end = match[2] ? parseInt(match[2], 10) : total - 1;
+      const safeEnd = Math.min(end, total - 1);
+      const chunk = new Uint8Array(buffer).subarray(start, safeEnd + 1);
+      return new NextResponse(chunk.buffer as ArrayBuffer, {
+        status: 206,
+        headers: {
+          "Content-Type": "video/mp4",
+          "Content-Range": `bytes ${start}-${safeEnd}/${total}`,
+          "Accept-Ranges": "bytes",
+          "Content-Length": String(chunk.length),
+        },
+      });
+    }
+  }
+
+  const bytes = new Uint8Array(buffer);
+  return new NextResponse(bytes.buffer as ArrayBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Accept-Ranges": "bytes",
+      "Content-Length": String(buffer.length),
+    },
+  });
+}

--- a/src/app/api/local-dataset/[...path]/route.ts
+++ b/src/app/api/local-dataset/[...path]/route.ts
@@ -22,7 +22,7 @@ export async function GET(
     );
   }
 
-  const pathSegments = (await params).path;
+  const pathSegments = (await params).path.map((s) => decodeURIComponent(s));
 
   // Validate: all segments must be safe (no ".." or absolute paths)
   if (pathSegments.some((s) => s === ".." || s.startsWith("/"))) {

--- a/src/app/api/local-dataset/[...path]/route.ts
+++ b/src/app/api/local-dataset/[...path]/route.ts
@@ -58,7 +58,7 @@ export async function GET(
       const end = match[2] ? parseInt(match[2], 10) : total - 1;
       const safeEnd = Math.min(end, total - 1);
       const chunk = new Uint8Array(buffer).subarray(start, safeEnd + 1);
-      return new NextResponse(chunk.buffer as ArrayBuffer, {
+      return new NextResponse(chunk, {
         status: 206,
         headers: {
           "Content-Type": "video/mp4",
@@ -71,7 +71,7 @@ export async function GET(
   }
 
   const bytes = new Uint8Array(buffer);
-  return new NextResponse(bytes.buffer as ArrayBuffer, {
+  return new NextResponse(bytes, {
     status: 200,
     headers: {
       "Content-Type": contentType,

--- a/src/app/api/local-datasets/route.ts
+++ b/src/app/api/local-datasets/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { readdir, readFile } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, relative } from "path";
 
 const LOCAL_DATASET_PATH = process.env.LOCAL_DATASET_PATH;
 
@@ -13,6 +13,58 @@ export type LocalDatasetEntry = {
   codebaseVersion: string;
 };
 
+const MAX_DEPTH = 5;
+
+/**
+ * Recursively discover dataset directories (those containing meta/info.json).
+ */
+async function discoverDatasets(
+  base: string,
+  dir: string,
+  depth: number,
+): Promise<LocalDatasetEntry[]> {
+  if (depth > MAX_DEPTH) return [];
+
+  let dirents: import("fs").Dirent[];
+  try {
+    dirents = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: LocalDatasetEntry[] = [];
+
+  for (const d of dirents) {
+    if (!d.isDirectory()) continue;
+    const childDir = join(dir, d.name);
+    const infoPath = join(childDir, "meta", "info.json");
+
+    try {
+      const raw = await readFile(infoPath, "utf-8");
+      const info = JSON.parse(raw) as Record<string, unknown>;
+      if (!info.features) {
+        // Not a valid dataset — recurse deeper
+        results.push(...(await discoverDatasets(base, childDir, depth + 1)));
+        continue;
+      }
+
+      results.push({
+        name: relative(base, childDir),
+        robotType: (info.robot_type as string) ?? null,
+        totalEpisodes: (info.total_episodes as number) ?? 0,
+        totalFrames: (info.total_frames as number) ?? 0,
+        fps: (info.fps as number) ?? 0,
+        codebaseVersion: (info.codebase_version as string) ?? "unknown",
+      });
+    } catch {
+      // No info.json — recurse deeper to find nested datasets
+      results.push(...(await discoverDatasets(base, childDir, depth + 1)));
+    }
+  }
+
+  return results;
+}
+
 export async function GET(): Promise<NextResponse> {
   if (!LOCAL_DATASET_PATH) {
     return NextResponse.json(
@@ -22,29 +74,8 @@ export async function GET(): Promise<NextResponse> {
   }
 
   const base = resolve(process.cwd(), LOCAL_DATASET_PATH);
-  const dirents = await readdir(base, { withFileTypes: true });
-  const datasets: LocalDatasetEntry[] = [];
-
-  for (const d of dirents) {
-    if (!d.isDirectory()) continue;
-    const infoPath = join(base, d.name, "meta", "info.json");
-    try {
-      const raw = await readFile(infoPath, "utf-8");
-      const info = JSON.parse(raw) as Record<string, unknown>;
-      if (!info.features) continue;
-      datasets.push({
-        name: d.name,
-        robotType: (info.robot_type as string) ?? null,
-        totalEpisodes: (info.total_episodes as number) ?? 0,
-        totalFrames: (info.total_frames as number) ?? 0,
-        fps: (info.fps as number) ?? 0,
-        codebaseVersion: (info.codebase_version as string) ?? "unknown",
-      });
-    } catch {
-      // No info.json or invalid — skip
-    }
-  }
-
+  const datasets = await discoverDatasets(base, base, 0);
   datasets.sort((a, b) => a.name.localeCompare(b.name));
+
   return NextResponse.json({ datasets });
 }

--- a/src/app/api/local-datasets/route.ts
+++ b/src/app/api/local-datasets/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { readdir, readFile } from "fs/promises";
+import { join, resolve } from "path";
+
+const LOCAL_DATASET_PATH = process.env.LOCAL_DATASET_PATH;
+
+export type LocalDatasetEntry = {
+  name: string;
+  robotType: string | null;
+  totalEpisodes: number;
+  totalFrames: number;
+  fps: number;
+  codebaseVersion: string;
+};
+
+export async function GET(): Promise<NextResponse> {
+  if (!LOCAL_DATASET_PATH) {
+    return NextResponse.json(
+      { error: "Local dataset mode not enabled" },
+      { status: 404 },
+    );
+  }
+
+  const base = resolve(process.cwd(), LOCAL_DATASET_PATH);
+  const dirents = await readdir(base, { withFileTypes: true });
+  const datasets: LocalDatasetEntry[] = [];
+
+  for (const d of dirents) {
+    if (!d.isDirectory()) continue;
+    const infoPath = join(base, d.name, "meta", "info.json");
+    try {
+      const raw = await readFile(infoPath, "utf-8");
+      const info = JSON.parse(raw) as Record<string, unknown>;
+      if (!info.features) continue;
+      datasets.push({
+        name: d.name,
+        robotType: (info.robot_type as string) ?? null,
+        totalEpisodes: (info.total_episodes as number) ?? 0,
+        totalFrames: (info.total_frames as number) ?? 0,
+        fps: (info.fps as number) ?? 0,
+        codebaseVersion: (info.codebase_version as string) ?? "unknown",
+      });
+    } catch {
+      // No info.json or invalid — skip
+    }
+  }
+
+  datasets.sort((a, b) => a.name.localeCompare(b.name));
+  return NextResponse.json({ datasets });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
+import { isLocalMode } from "@/utils/localDatasetShared";
+import type { LocalDatasetEntry } from "@/app/api/local-datasets/route";
 
 declare global {
   interface Window {
@@ -19,7 +21,7 @@ declare global {
 export default function Home() {
   return (
     <Suspense fallback={null}>
-      <HomeInner />
+      {isLocalMode() ? <LocalDatasetBrowser /> : <HomeInner />}
     </Suspense>
   );
 }
@@ -29,6 +31,174 @@ const EXAMPLE_DATASETS = [
   "imstevenpmwork/thanos_picking_power_gem",
   "lerobot/aloha_static_cups_open",
 ];
+
+function LocalDatasetBrowser() {
+  const router = useRouter();
+  const [datasets, setDatasets] = useState<LocalDatasetEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/local-datasets", { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to list local datasets");
+        const data = (await res.json()) as { datasets: LocalDatasetEntry[] };
+        setDatasets(data.datasets);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        {/* Header */}
+        <h1 className="text-3xl font-bold mb-1 tracking-tight">
+          LeRobot{" "}
+          <span className="bg-gradient-to-r from-sky-400 to-indigo-400 bg-clip-text text-transparent">
+            Dataset
+          </span>{" "}
+          Visualizer
+        </h1>
+        <p className="text-white/50 text-sm mb-8">
+          Local mode &mdash; browsing datasets from{" "}
+          <code className="text-sky-400/80 bg-white/5 px-1.5 py-0.5 rounded text-xs">
+            LOCAL_DATASET_PATH
+          </code>
+        </p>
+
+        {/* Loading state */}
+        {loading && (
+          <div className="flex items-center gap-2 text-white/50 text-sm">
+            <svg
+              className="animate-spin w-4 h-4"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v8H4z"
+              />
+            </svg>
+            Scanning datasets…
+          </div>
+        )}
+
+        {/* Error state */}
+        {error && <p className="text-red-400 text-sm">Error: {error}</p>}
+
+        {/* Empty state */}
+        {!loading && !error && datasets.length === 0 && (
+          <p className="text-white/40 text-sm">
+            No datasets found. Make sure each dataset folder contains{" "}
+            <code className="text-white/60">meta/info.json</code>.
+          </p>
+        )}
+
+        {/* Dataset list */}
+        {!loading && datasets.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs text-white/40 uppercase tracking-widest mb-3 font-medium">
+              {datasets.length} dataset{datasets.length !== 1 ? "s" : ""} found
+            </p>
+            <div className="grid gap-3">
+              {datasets.map((ds) => (
+                <button
+                  key={ds.name}
+                  type="button"
+                  className="group w-full text-left rounded-lg border border-white/10 bg-white/[0.03] hover:bg-white/[0.07] hover:border-sky-500/40 px-5 py-4 transition-all"
+                  onClick={() =>
+                    router.push(`/local/${encodeURIComponent(ds.name)}`)
+                  }
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3 min-w-0">
+                      {/* Folder icon */}
+                      <svg
+                        className="w-5 h-5 text-sky-400/70 shrink-0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.06-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+                        />
+                      </svg>
+                      <span className="font-medium text-white group-hover:text-sky-300 transition-colors truncate">
+                        {ds.name}
+                      </span>
+                    </div>
+                    {/* Arrow */}
+                    <svg
+                      className="w-4 h-4 text-white/20 group-hover:text-sky-400 transition-colors shrink-0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m8.25 4.5 7.5 7.5-7.5 7.5"
+                      />
+                    </svg>
+                  </div>
+                  {/* Metadata row */}
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-white/40">
+                    {ds.robotType && (
+                      <span>
+                        Robot:{" "}
+                        <span className="text-white/60">{ds.robotType}</span>
+                      </span>
+                    )}
+                    <span>
+                      Episodes:{" "}
+                      <span className="text-white/60">{ds.totalEpisodes}</span>
+                    </span>
+                    <span>
+                      Frames:{" "}
+                      <span className="text-white/60">
+                        {ds.totalFrames.toLocaleString()}
+                      </span>
+                    </span>
+                    <span>
+                      FPS: <span className="text-white/60">{ds.fps}</span>
+                    </span>
+                    <span>
+                      Version:{" "}
+                      <span className="text-white/60">
+                        {ds.codebaseVersion}
+                      </span>
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function HomeInner() {
   const searchParams = useSearchParams();

--- a/src/utils/localDatasetShared.ts
+++ b/src/utils/localDatasetShared.ts
@@ -1,0 +1,44 @@
+/**
+ * Client-safe local dataset helpers (no Node.js builtins).
+ *
+ * These functions can be imported in both server and client components.
+ * All filesystem access goes through the /api/local-dataset/ route.
+ */
+
+export function isLocalMode(): boolean {
+  return (
+    !!process.env.LOCAL_DATASET_PATH || !!process.env.NEXT_PUBLIC_LOCAL_MODE
+  );
+}
+
+/**
+ * Strips the org prefix from a repoId ("org/dataset" → "dataset").
+ */
+export function datasetNameFromRepoId(repoId: string): string {
+  const slash = repoId.indexOf("/");
+  return slash === -1 ? repoId : repoId.slice(slash + 1);
+}
+
+/**
+ * Returns a URL to the local-dataset API route.
+ * Server-side: absolute URL (needed for server-side fetch).
+ * Client-side: relative URL (works naturally in the browser).
+ */
+function localApiUrl(dataset: string, path: string): string {
+  const rel = `/api/local-dataset/${dataset}/${path}`;
+  if (typeof window !== "undefined") {
+    return rel;
+  }
+  const port = process.env.PORT || "3000";
+  return `http://localhost:${port}${rel}`;
+}
+
+/**
+ * Builds a URL for reading a dataset file.
+ * In local mode → points to the /api/local-dataset/ route.
+ * Otherwise this function should NOT be called (use buildVersionedUrl).
+ */
+export function buildLocalUrl(repoId: string, path: string): string {
+  const dataset = datasetNameFromRepoId(repoId);
+  return localApiUrl(dataset, path);
+}

--- a/src/utils/versionUtils.ts
+++ b/src/utils/versionUtils.ts
@@ -2,6 +2,8 @@
  * Utility functions for checking dataset version compatibility
  */
 
+import { isLocalMode, buildLocalUrl } from "@/utils/localDatasetShared";
+
 const DATASET_URL =
   process.env.DATASET_URL || "https://huggingface.co/datasets";
 
@@ -73,26 +75,39 @@ export async function getDatasetInfo(repoId: string): Promise<DatasetInfo> {
   console.log(`[perf] getDatasetInfo cache MISS for ${repoId} — fetching`);
 
   try {
-    const testUrl = `${DATASET_URL}/${repoId}/resolve/main/meta/info.json`;
+    let data: unknown;
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    if (isLocalMode()) {
+      const localUrl = buildLocalUrl(repoId, "meta/info.json");
+      const response = await fetch(localUrl, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch local dataset info: ${response.status}`,
+        );
+      }
+      data = await response.json();
+    } else {
+      const testUrl = `${DATASET_URL}/${repoId}/resolve/main/meta/info.json`;
 
-    const response = await fetch(testUrl, {
-      method: "GET",
-      cache: "no-store",
-      signal: controller.signal,
-    });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-    clearTimeout(timeoutId);
+      const response = await fetch(testUrl, {
+        method: "GET",
+        cache: "no-store",
+        signal: controller.signal,
+      });
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch dataset info: ${response.status}`);
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch dataset info: ${response.status}`);
+      }
+
+      data = await response.json();
     }
 
-    const data = await response.json();
-
-    if (!data.features) {
+    if (!(data as Record<string, unknown>).features) {
       throw new Error(
         "Dataset info.json does not have the expected features structure",
       );
@@ -149,5 +164,8 @@ export function buildVersionedUrl(
   version: string,
   path: string,
 ): string {
+  if (isLocalMode()) {
+    return buildLocalUrl(repoId, path);
+  }
   return `${DATASET_URL}/${repoId}/resolve/main/${path}`;
 }


### PR DESCRIPTION
## Summary
This PR introduces a local mode for running the visualizer against datasets stored on the local filesystem

## Changes
### Local Dataset Mode
- New API routes (/api/local-datasets, /api/local-dataset/[...path]) to serve local dataset files and directory listings
- Nested directory scanning — local dataset discovery now walks subdirectories so datasets stored under org-prefixed folders (e.g. lerobot/dataset_name/) are found correctly
- Shared utility (localDatasetShared.ts) for resolving the local dataset root path
- Landing page updated with a dataset exploration UI that lists available local datasets when running in local mode
- Fix: URI-encoded characters in nested dataset names are now decoded correctly in route params
- Dockerfile and README updated with instructions for mounting and running local datasets

### Bug Fix
- SimpleVideosPlayer:  handle video .play() promise rejections (e.g. when playback is interrupted by a seek)