### PR TITLE
feat: add Doctor tab with lerobot-doctor diagnostics

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -48,6 +48,7 @@ type ActiveTab =
   | "frames"
   | "insights"
   | "filtering"
+  | "doctor"
   | "urdf";
 
 export default function EpisodeViewer({
@@ -548,6 +549,20 @@ function EpisodeViewerInner({
             <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
           )}
         </button>
+        <button
+          className={`px-6 py-2.5 text-sm font-medium transition-colors relative ${
+            activeTab === "doctor"
+              ? "text-orange-400"
+              : "text-slate-400 hover:text-slate-200"
+          }`}
+          onClick={() => handleTabChange("doctor")}
+          title="Dataset quality diagnostics (powered by lerobot-doctor)"
+        >
+          Doctor
+          {activeTab === "doctor" && (
+            <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
+          )}
+        </button>
         {hasURDFSupport(datasetInfo.robot_type) &&
           datasetInfo.codebase_version >= "v3.0" && (
             <button
@@ -711,6 +726,38 @@ function EpisodeViewerInner({
                 }}
               />
             </Suspense>
+          )}
+
+          {activeTab === "doctor" && (
+            <div className="flex flex-col h-full">
+              <div className="flex items-center justify-between px-1 pb-2 text-xs text-slate-400">
+                <span>
+                  Dataset quality diagnostics &mdash; powered by{" "}
+                  <a
+                    href="https://github.com/jashshah999/lerobot-doctor"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-slate-200"
+                  >
+                    lerobot-doctor
+                  </a>
+                </span>
+                <a
+                  href={`https://jashshah999-lerobot-doctor.hf.space/?dataset=${org}/${dataset}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-slate-200"
+                >
+                  Open in new tab
+                </a>
+              </div>
+              <iframe
+                src={`https://jashshah999-lerobot-doctor.hf.space/?dataset=${org}/${dataset}`}
+                title="lerobot-doctor"
+                className="flex-1 w-full rounded border border-slate-700 bg-white"
+                sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+              />
+            </div>
           )}
 
           {activeTab === "urdf" && (


### PR DESCRIPTION
## Summary

Adds a **Doctor** tab to the episode viewer that surfaces dataset-quality diagnostics (corrupted timestamps, dropped frames, frozen/clipped actions, metadata inconsistencies, video issues, stuck actuators, etc.) right next to the existing tabs.

The tab iframes the [lerobot-doctor](https://huggingface.co/spaces/jashshah999/lerobot-doctor) HF Space and passes the current `org/dataset` via a `?dataset=` URL param, so diagnostics auto-run for whatever dataset the user is already viewing.

Discussed on Discord with @imstevenpmwork — he suggested centralizing this as an extra tab in `visualize_dataset` rather than keeping it a separate Space.

### Why iframe instead of porting

- The Python checks (metadata, temporal, actions, videos, statistics, episodes, consistency, training, anomalies, portability) live in the [`lerobot-doctor`](https://github.com/jashshah999/lerobot-doctor) package on PyPI and are also used via CLI / CI. Keeping one source of truth means updates flow automatically — no need to reimplement checks in TypeScript.
- Zero new dependencies in this repo.
- The Space is public and already linked from the LeRobot ecosystem; iframing adds one `<iframe>` and a tab button.

### What changed

- `src/app/[org]/[dataset]/[episode]/episode-viewer.tsx`
  - Added `"doctor"` to the `ActiveTab` union
  - Added a **Doctor** tab button between Action Insights and 3D Replay
  - Added the tab body: small header with attribution + "Open in new tab" link, then the iframe filling the remaining height
- No new dependencies, no test changes needed

### Attribution

Tab label stays neutral ("Doctor"); attribution to `lerobot-doctor` is shown in the tab body and inside the iframed Space itself (hero links + report footer). Happy to adjust placement if you'd prefer it more subtle or more prominent.

## Test plan

- [x] `bun run format` — clean
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 132/132 pass
- [x] Manual: open any `/org/dataset/episode_0` page, click **Doctor** tab, confirm iframe loads with correct dataset pre-filled and checks auto-run
- [x] Manual: "Open in new tab" link opens the Space standalone with `?dataset=` preserved

cc @imstevenpmwork