### PR TITLE
fix: exclude reserved step signals and subtask_index from charts

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,8 +37,29 @@ export const HTTP = {
   TIMEOUT_MS: 10000,
 } as const;
 
-// Excluded columns by dataset version
+// Excluded columns by dataset version.
+// Reserved names from lerobot: `next.reward`, `next.done`, `next.truncated` are
+// auto-populated step signals and should not be rendered as chart series.
+// `subtask_index` is the v3.0 subtask pointer (maps into meta/subtasks.parquet).
 export const EXCLUDED_COLUMNS = {
-  V2: ["timestamp", "frame_index", "episode_index", "index", "task_index"],
-  V3: ["index", "task_index", "episode_index", "frame_index", "next.done"],
+  V2: [
+    "timestamp",
+    "frame_index",
+    "episode_index",
+    "index",
+    "task_index",
+    "next.reward",
+    "next.done",
+    "next.truncated",
+  ],
+  V3: [
+    "index",
+    "task_index",
+    "episode_index",
+    "frame_index",
+    "next.reward",
+    "next.done",
+    "next.truncated",
+    "subtask_index",
+  ],
 } as const;


### PR DESCRIPTION
## Summary
- `lerobot` reserves three step signals (`src/lerobot/utils/constants.py`): `next.reward`, `next.done`, `next.truncated`. Only `next.done` was in `EXCLUDED_COLUMNS`, so the other two leaked into chart series.
- v3.0 also introduces `subtask_index` as a pointer into `meta/subtasks.parquet` — it has no meaning as a time-series and was getting rendered.
- Adds all reserved names to both `EXCLUDED_COLUMNS.V2` and `EXCLUDED_COLUMNS.V3`.

## Test plan
- [x] `bun run validate` passes (type-check, lint, format:check, 132 tests)
- [ ] Open a v3.0 dataset that logs `next.reward` and confirm it no longer appears in the chart panel
- [ ] Open a v3.0 dataset with `subtask_index` and confirm it no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)