### PR TITLE
fix(v3): look up task by task_index column, not row position

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -869,10 +869,18 @@ async function loadEpisodeDataV3(
         if (tasksData.length > 0) {
           const taskIndexNum = bigIntToNumber(episodeData[0].task_index, -1);
 
-          if (taskIndexNum >= 0 && taskIndexNum < tasksData.length) {
-            const taskData = tasksData[taskIndexNum];
-            const rawTask = taskData.__index_level_0__ ?? taskData.task;
-            task = typeof rawTask === "string" ? rawTask : undefined;
+          if (taskIndexNum >= 0) {
+            // lerobot writes tasks.parquet from a DataFrame with the task
+            // string as the (possibly named) index and `task_index` as a
+            // column. Row order is not guaranteed to match task_index, so
+            // match on the column value.
+            const taskData = tasksData.find(
+              (row) => bigIntToNumber(row.task_index, -1) === taskIndexNum,
+            );
+            if (taskData) {
+              const rawTask = taskData.__index_level_0__ ?? taskData.task;
+              task = typeof rawTask === "string" ? rawTask : undefined;
+            }
           }
         }
       } catch {


### PR DESCRIPTION
## Summary
- `lerobot` builds `tasks.parquet` from `pd.DataFrame({\"task_index\": task_indices}, index=pd.Index(tasks, name=\"task\"))` (see `src/lerobot/datasets/dataset_metadata.py:391`). The task string is the index, `task_index` is a column.
- The visualizer was indexing by array position (`tasksData[taskIndexNum]`), which assumes row order matches `task_index` — pandas doesn't guarantee this, so future reorderings (e.g. during aggregation/conversion) could silently mis-label tasks.
- Filter by the `task_index` column value instead. Task-string extraction keeps the existing `__index_level_0__ ?? task` fallback chain.

## Test plan
- [x] `bun run validate` passes (type-check, lint, format:check, 132 tests)
- [ ] Open a v3.0 dataset with multiple tasks and confirm the correct task label appears on the episode page

🤖 Generated with [Claude Code](https://claude.com/claude-code)