### PR TITLE
feat(v3): read episode tasks from metadata for multi-task support

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -97,7 +97,8 @@ type EpisodeMetadataV3 = {
   video_from_timestamp: number;
   video_to_timestamp: number;
   length: number;
-  [key: string]: string | number;
+  tasks?: string[];
+  [key: string]: string | number | string[] | undefined;
 };
 
 type ColumnDef = {
@@ -819,9 +820,15 @@ async function loadEpisodeDataV3(
     const { chartDataGroups, flatChartData, ignoredColumns } =
       processEpisodeDataForCharts(episodeData, info, episodeMetadata);
 
-    // First check for language_instruction fields in the data (preferred)
+    // Prefer the authoritative `tasks` list on the episode's own metadata
+    // (v3.0 stores it as list[str] — see lerobot dataset_metadata.save_episode).
     let task: string | undefined;
-    if (episodeData.length > 0) {
+    if (episodeMetadata.tasks && episodeMetadata.tasks.length > 0) {
+      task = episodeMetadata.tasks.join("\n");
+    }
+
+    // Fall back to per-frame language_instruction fields
+    if (!task && episodeData.length > 0) {
       const languageInstructions: string[] = [];
 
       const extractInstructions = (row: Record<string, unknown>) => {
@@ -1120,8 +1127,11 @@ function extractVideoInfoV3WithSegmentation(
       segmentStart: number,
       segmentEnd: number;
 
-    const toNum = (v: string | number): number =>
-      typeof v === "string" ? parseFloat(v) || 0 : v;
+    const toNum = (v: string | number | string[] | undefined): number => {
+      if (typeof v === "string") return parseFloat(v) || 0;
+      if (typeof v === "number") return v;
+      return 0;
+    };
 
     if (cameraSpecificKeys.length > 0) {
       chunkIndex = toNum(episodeMetadata[`videos/${videoKey}/chunk_index`]);
@@ -1255,6 +1265,12 @@ function parseEpisodeRowSimple(
         videoToTs = toNumSafe(row[`${videoBaseName}/to_timestamp`]) || 30;
       }
 
+      // lerobot writes episode.tasks as list[str] (v3.0 multi-task support).
+      const rawTasks = row["tasks"];
+      const tasks = Array.isArray(rawTasks)
+        ? rawTasks.filter((t): t is string => typeof t === "string")
+        : undefined;
+
       const episodeData: EpisodeMetadataV3 = {
         episode_index: toBigIntSafe(row["episode_index"]),
         data_chunk_index: toBigIntSafe(row["data/chunk_index"]),
@@ -1266,6 +1282,7 @@ function parseEpisodeRowSimple(
         video_file_index: videoFileIndex,
         video_from_timestamp: videoFromTs,
         video_to_timestamp: videoToTs,
+        ...(tasks && tasks.length > 0 ? { tasks } : {}),
       };
 
       // Store per-camera metadata for extractVideoInfoV3WithSegmentation


### PR DESCRIPTION
## Summary
- v3.0 episodes can have multiple tasks — lerobot writes them as `list[str]` in the `tasks` column of `meta/episodes/*.parquet` (see `src/lerobot/datasets/dataset_metadata.py:497`).
- The visualizer only looked up a single task via `episodeData[0].task_index` → `tasks.parquet`, so episodes whose frames span multiple tasks lost all but the first.
- Parse the `tasks` list in `parseEpisodeRowSimple` and prefer it over `language_instruction` fields and the `tasks.parquet` lookup. Multiple tasks are joined with `\n`, matching the existing display convention for multi-line instructions.
- Widens the `EpisodeMetadataV3` index signature to accommodate `string[]`, and `toNum` to handle the widened types.

## Test plan
- [x] `bun run validate` passes (type-check, lint, format:check, 132 tests)
- [ ] Open a v3.0 single-task episode and confirm the task label is unchanged
- [ ] Open a v3.0 multi-task episode and confirm all tasks are shown, separated by newlines
- [ ] Confirm v2.x task extraction is unaffected (this code path only runs for v3.0)

## Note
Touches the same region as #61 — whichever merges first, the other will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)