### PR TITLE
tweak: move 3D Replay tab to second position

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -497,6 +497,22 @@ function EpisodeViewerInner({
             <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
           )}
         </button>
+        {hasURDFSupport(datasetInfo.robot_type) &&
+          datasetInfo.codebase_version >= "v3.0" && (
+            <button
+              className={`px-6 py-2.5 text-sm font-medium transition-colors relative ${
+                activeTab === "urdf"
+                  ? "text-orange-400"
+                  : "text-slate-400 hover:text-slate-200"
+              }`}
+              onClick={() => handleTabChange("urdf")}
+            >
+              3D Replay
+              {activeTab === "urdf" && (
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
+              )}
+            </button>
+          )}
         <button
           className={`px-6 py-2.5 text-sm font-medium transition-colors relative ${
             activeTab === "statistics"
@@ -563,22 +579,6 @@ function EpisodeViewerInner({
             <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
           )}
         </button>
-        {hasURDFSupport(datasetInfo.robot_type) &&
-          datasetInfo.codebase_version >= "v3.0" && (
-            <button
-              className={`px-6 py-2.5 text-sm font-medium transition-colors relative ${
-                activeTab === "urdf"
-                  ? "text-orange-400"
-                  : "text-slate-400 hover:text-slate-200"
-              }`}
-              onClick={() => handleTabChange("urdf")}
-            >
-              3D Replay
-              {activeTab === "urdf" && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-orange-500" />
-              )}
-            </button>
-          )}
       </div>
 
       {/* Body: sidebar + content */}


### PR DESCRIPTION
## Summary
- Reorders the episode-viewer tab bar so **3D Replay** appears right after **Episodes**, promoting it above Statistics/Filtering/Frames/Action Insights/Doctor.
- Conditional rendering (requires `hasURDFSupport` + v3.0) is preserved.

## Test plan
- [x] `bun run validate` passes
- [ ] Visual check: open an episode for a supported robot (SO-101/SO-100/OpenArm/G1) and confirm tab order is Episodes → 3D Replay → Statistics → …
- [ ] Open an episode for an unsupported robot and confirm 3D Replay is still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)