### PR TITLE
fix(3d): disable playback controls while URDF is loading

### DIFF
--- a/src/components/urdf-playback-bar.tsx
+++ b/src/components/urdf-playback-bar.tsx
@@ -11,6 +11,7 @@ interface UrdfPlaybackBarProps {
   trailEnabled: boolean;
   onTrailToggle: () => void;
   onFrameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
 }
 
 export default function UrdfPlaybackBar({
@@ -22,16 +23,21 @@ export default function UrdfPlaybackBar({
   trailEnabled,
   onTrailToggle,
   onFrameChange,
+  disabled = false,
 }: UrdfPlaybackBarProps) {
   const currentTime = totalFrames > 0 ? (frame / fps).toFixed(2) : "0.00";
   const totalTime = (totalFrames / fps).toFixed(2);
 
   return (
-    <div className="flex items-center gap-3">
+    <div
+      className={`flex items-center gap-3 ${disabled ? "opacity-50" : ""}`}
+      aria-busy={disabled}
+    >
       {/* Play/Pause */}
       <button
         onClick={onPlayPause}
-        className="w-8 h-8 flex items-center justify-center rounded bg-orange-600 hover:bg-orange-500 text-white transition-colors shrink-0"
+        disabled={disabled}
+        className="w-8 h-8 flex items-center justify-center rounded bg-orange-600 hover:bg-orange-500 disabled:bg-slate-700 disabled:hover:bg-slate-700 disabled:cursor-not-allowed text-white transition-colors shrink-0"
       >
         {playing ? (
           <svg width="12" height="14" viewBox="0 0 12 14">
@@ -48,7 +54,8 @@ export default function UrdfPlaybackBar({
       {/* Trail toggle */}
       <button
         onClick={onTrailToggle}
-        className={`px-2 h-8 text-xs rounded transition-colors shrink-0 ${
+        disabled={disabled}
+        className={`px-2 h-8 text-xs rounded transition-colors shrink-0 disabled:cursor-not-allowed ${
           trailEnabled
             ? "bg-orange-600/30 text-orange-400 border border-orange-500"
             : "bg-slate-700 text-slate-400 border border-slate-600"
@@ -65,7 +72,8 @@ export default function UrdfPlaybackBar({
         max={Math.max(totalFrames - 1, 0)}
         value={frame}
         onChange={onFrameChange}
-        className="flex-1 h-1.5 accent-orange-500 cursor-pointer"
+        disabled={disabled}
+        className="flex-1 h-1.5 accent-orange-500 cursor-pointer disabled:cursor-not-allowed"
       />
       <span className="text-xs text-slate-400 tabular-nums w-28 text-right shrink-0">
         {currentTime}s / {totalTime}s

--- a/src/components/urdf-viewer.tsx
+++ b/src/components/urdf-viewer.tsx
@@ -690,12 +690,22 @@ export default function URDFViewer({
     [],
   );
 
+  // URDF meshes download async from the Hub bucket. Until joints are reported
+  // back from URDFLoader, playback/scrub inputs would drive an empty scene, so
+  // we gate interactions (and pause if already playing).
+  const urdfLoading = urdfJointNames.length === 0;
+
+  useEffect(() => {
+    if (urdfLoading) setPlaying(false);
+  }, [urdfLoading]);
+
   const handlePlayPause = useCallback(() => {
+    if (urdfLoading) return;
     setPlaying((prev) => {
       if (!prev) frameRef.current = frame;
       return !prev;
     });
-  }, [frame]);
+  }, [frame, urdfLoading]);
 
   useEffect(() => {
     if (playToggleRef) playToggleRef.current = handlePlayPause;
@@ -785,10 +795,12 @@ export default function URDFViewer({
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* 3D Viewport */}
       <div className="flex-1 min-h-0 bg-slate-950 rounded-lg overflow-hidden border border-slate-700 relative">
-        {episodeLoading && (
+        {(episodeLoading || urdfLoading) && (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-slate-950/70">
             <span className="text-white text-lg animate-pulse">
-              Loading episode {selectedEpisode}…
+              {urdfLoading
+                ? "Loading 3D model…"
+                : `Loading episode ${selectedEpisode}…`}
             </span>
           </div>
         )}
@@ -847,6 +859,7 @@ export default function URDFViewer({
           trailEnabled={trailEnabled}
           onTrailToggle={() => setTrailEnabled((v) => !v)}
           onFrameChange={handleFrameChange}
+          disabled={urdfLoading}
         />
 
         {/* Collapsible joint mapping */}


### PR DESCRIPTION
## Summary
The 3D Replay tab pulls ~180 MB of URDF + meshes from the Hub on first open. Play/scrub/trail buttons were clickable during that window, which was confusing: you could hit Play and the timeline advanced while the scene was still empty.

- Derive `urdfLoading` from `urdfJointNames` (populated when `URDFLoader` finishes parsing).
- Replace the small in-canvas "Loading robot…" text with a full-panel overlay that reads **"Loading 3D model…"** (coexists with the existing episode-loading overlay).
- Add a `disabled` prop to `UrdfPlaybackBar`; when loading, play/trail/scrub all show disabled styles and ignore input.
- Guard `handlePlayPause` and auto-pause if we ever re-enter loading.

## Test plan
- [x] `bun run validate` passes
- [ ] Open the 3D Replay tab cold (no Hub/browser cache) and confirm overlay + disabled controls during load
- [ ] Once loaded, confirm play/scrub/trail all work normally
- [ ] Switch episodes and confirm the "Loading episode N…" overlay still appears (not the URDF one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)