### PR TITLE
docs(claude): capture v3 multi-chunk + URDF viewer gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,9 @@ Three versions are supported. Version is detected from `meta/info.json` → `cod
 - Integer columns from parquet come out as **BigInt** — always use `bigIntToNumber()` from `src/utils/typeGuards.ts`
 - Row-range selection: `dataset_from_index` / `dataset_to_index` allow reading only the episode's rows from a shared parquet file
 - Fallback format uses numeric keys `"0"`.."9"` when column names are unavailable
+- Episode metadata can span **multiple chunks** (when episode count exceeds `chunks_size`). Always walk via the `iterateEpisodeMetadataFilesV3(repoId, version)` async generator in `fetch-data.ts` — it advances chunk-000 → chunk-001 → … and stops on the first missing `file-000`. Never hardcode `chunk-000`.
+- Multi-task episodes: episode-metadata rows carry a `tasks` field (`list[str]`) — prefer it over the legacy single `task_index` lookup. `EpisodeMetadataV3.tasks?: string[]` exposes it.
+- `meta/tasks.parquet` lookup: rows are **not** ordered by `task_index`, and the task string lives in a named pandas index (`__index_level_0__`). Always filter by the `task_index` **column** (`row.task_index === taskIndexNum`), never by row position.
 
 ### v2.x path construction
 
@@ -112,5 +115,26 @@ Built by `buildVersionedUrl(repoId, version, path)`. The `version` param is acce
 
 ## Excluded columns (not shown in charts)
 
-- v2.x: `timestamp`, `frame_index`, `episode_index`, `index`, `task_index`
-- v3.0: `index`, `task_index`, `episode_index`, `frame_index`, `next.done`
+Reserved/bookkeeping columns from lerobot — see `EXCLUDED_COLUMNS` in `src/utils/constants.ts`:
+
+- v2.x: `timestamp`, `frame_index`, `episode_index`, `index`, `task_index`, `next.reward`, `next.done`, `next.truncated`
+- v3.0: `index`, `task_index`, `episode_index`, `frame_index`, `next.reward`, `next.done`, `next.truncated`, `subtask_index`
+
+## 3D URDF viewer (`src/components/urdf-viewer.tsx`)
+
+- URDFs and meshes are hosted in the HF bucket `lerobot/robot-urdfs` — base URL `https://huggingface.co/buckets/lerobot/robot-urdfs/resolve` (no `/main` segment; buckets are unbranched). Override with `NEXT_PUBLIC_URDF_BASE_URL` for local development.
+- Asset layout under the bucket: `g1/`, `openarm/`, `so101/` (both SO-100 and SO-101 live here).
+- **URDFLoader gotcha**: after our `loadMeshCb` returns, `URDFLoader.js` does `if (obj instanceof THREE.Mesh) obj.material = <urdf-material>`, overwriting any material we set. Workaround: wrap the loaded mesh in a `THREE.Group` so the `instanceof Mesh` check fails. DAE returns a Group already; STL must be wrapped explicitly.
+- **STLLoader event ordering**: `manager.itemEnd(url)` fires _before_ the user `onLoad` callback, so `manager.onLoad` can fire before meshes are attached to the robot tree. Defer post-load work (auto-fit camera, shadow flags) with `setTimeout(..., 0)`. Don't try to rebuild materials in `manager.onLoad` — pick the archetype color directly inside `loadMeshCb`.
+- **OpenArm DAE files ship 23 stray `PointLight`s** that drown out scene lighting. Strip non-`AmbientLight` lights from `collada.scene` before adding it to the robot.
+- Scene setup: `<Canvas shadows>` with `ACESFilmicToneMapping` (exposure 0.9), 3-point directional + ambient lights, `<Environment preset="studio" background={false} />`, `<color attach="background" args={["#1a2433"]} />`. `<OrbitControls makeDefault />` is required so `useThree().controls` exposes the controls for auto-fit.
+
+## Design system
+
+CSS tokens in `src/app/globals.css` (Tailwind v4 `@theme inline`):
+
+- Surfaces: `--bg #0a0e17`, `--surface-0`, `--surface-1`, `--surface-2`
+- Text: `--text-primary`, `--text-muted`, `--text-faint`
+- Accent: `--accent #38bdf8` (cyan) — primary interactive color across UI
+- Helpers: `.panel`, `.panel-raised`, `.tabular` (tabular-nums)
+- **Color semantics**: cyan = primary/active, orange (`orange-400/500`) is reserved for **flagged-episode** UI only — don't reuse it for generic accents.


### PR DESCRIPTION
## Summary
- Document v3.0 multi-chunk episode metadata (`iterateEpisodeMetadataFilesV3`), `tasks` list on rows, and the `tasks.parquet` lookup-by-column rule
- Update `EXCLUDED_COLUMNS` reference: add `next.reward` / `next.truncated` (v2 + v3) and `subtask_index` (v3)
- Add 3D URDF viewer section: HF bucket base URL + `NEXT_PUBLIC_URDF_BASE_URL`, the URDFLoader `instanceof Mesh` material-override workaround, STLLoader `itemEnd` ordering, OpenArm DAE stray PointLights, scene/lighting setup
- Add Design system section: `globals.css` tokens, cyan accent, orange reserved for flag semantic

Docs only — no code changes.

## Test plan
- [x] `bun run format` clean