### PR TITLE
fix(auth): expose OAuth config via API for Docker Spaces

### DIFF
--- a/src/app/api/auth/config/route.ts
+++ b/src/app/api/auth/config/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+// HF Spaces auto-injects `window.huggingface.variables.OAUTH_CLIENT_ID` for
+// static Spaces only. Docker Spaces (this one) just get OAUTH_CLIENT_ID /
+// OAUTH_SCOPES as container env vars, so we surface them to the client via
+// this endpoint. The client_id and scopes are public; the secret stays
+// server-side and never leaves the proxy.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const clientId = process.env.OAUTH_CLIENT_ID;
+  const scopes = process.env.OAUTH_SCOPES;
+  if (!clientId) {
+    return NextResponse.json({ enabled: false });
+  }
+  return NextResponse.json({
+    enabled: true,
+    clientId,
+    scopes: scopes ?? "openid profile",
+  });
+}

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -14,19 +14,17 @@ import {
 } from "@huggingface/hub";
 import { AUTH_STORAGE_KEY } from "@/utils/auth";
 
-interface HfSpaceVariables {
-  OAUTH_CLIENT_ID?: string;
-  OAUTH_SCOPES?: string;
-}
-
-interface HfWindow extends Window {
-  huggingface?: { variables?: HfSpaceVariables };
+interface OAuthAppConfig {
+  clientId: string;
+  scopes: string;
 }
 
 interface AuthContextValue {
   oauth: OAuthResult | null;
-  // Whether OAuth is configured for this deployment (i.e. running on an HF
-  // Space with hf_oauth enabled). When false, the button hides itself.
+  // Whether OAuth is configured for this deployment. Determined by hitting
+  // /api/auth/config — the server reads OAUTH_CLIENT_ID from its env, which
+  // HF Spaces injects when `hf_oauth: true` is set in the README. When
+  // unconfigured, the button hides itself.
   isAuthAvailable: boolean;
   signIn: () => Promise<void>;
   signOut: () => void;
@@ -68,52 +66,73 @@ function isExpired(result: OAuthResult): boolean {
   return expDate.getTime() <= Date.now();
 }
 
+async function fetchOAuthConfig(): Promise<OAuthAppConfig | null> {
+  try {
+    const res = await fetch("/api/auth/config");
+    if (!res.ok) return null;
+    const data = (await res.json()) as
+      | { enabled: false }
+      | { enabled: true; clientId: string; scopes: string };
+    if (!data.enabled) return null;
+    return { clientId: data.clientId, scopes: data.scopes };
+  } catch {
+    return null;
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [oauth, setOauth] = useState<OAuthResult | null>(null);
-  const [isAuthAvailable, setIsAuthAvailable] = useState(false);
+  const [config, setConfig] = useState<OAuthAppConfig | null>(null);
 
   useEffect(() => {
-    const w = window as HfWindow;
-    const available = !!w.huggingface?.variables?.OAUTH_CLIENT_ID;
-    setIsAuthAvailable(available);
-    if (!available) return;
+    let cancelled = false;
 
-    const stored = window.localStorage.getItem(AUTH_STORAGE_KEY);
-    if (stored) {
-      try {
-        const parsed = JSON.parse(stored) as OAuthResult;
-        if (isExpired(parsed)) {
+    fetchOAuthConfig().then((cfg) => {
+      if (cancelled || !cfg) return;
+      setConfig(cfg);
+
+      const stored = window.localStorage.getItem(AUTH_STORAGE_KEY);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as OAuthResult;
+          if (isExpired(parsed)) {
+            window.localStorage.removeItem(AUTH_STORAGE_KEY);
+            clearSessionCookie();
+          } else {
+            setOauth(parsed);
+            setSessionCookie(parsed.accessToken);
+            return;
+          }
+        } catch {
           window.localStorage.removeItem(AUTH_STORAGE_KEY);
-          clearSessionCookie();
-        } else {
-          setOauth(parsed);
-          setSessionCookie(parsed.accessToken);
-          return;
         }
-      } catch {
-        window.localStorage.removeItem(AUTH_STORAGE_KEY);
       }
-    }
 
-    oauthHandleRedirectIfPresent()
-      .then((result) => {
-        if (result) {
+      oauthHandleRedirectIfPresent()
+        .then((result) => {
+          if (cancelled || !result) return;
           window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(result));
           setOauth(result);
           setSessionCookie(result.accessToken);
-        }
-      })
-      .catch((err) => {
-        console.error("OAuth redirect handling failed", err);
-      });
+        })
+        .catch((err) => {
+          console.error("OAuth redirect handling failed", err);
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const signIn = useCallback(async () => {
-    const w = window as HfWindow;
-    const scopes = w.huggingface?.variables?.OAUTH_SCOPES;
-    const url = await oauthLoginUrl(scopes ? { scopes } : {});
+    if (!config) return;
+    const url = await oauthLoginUrl({
+      clientId: config.clientId,
+      scopes: config.scopes,
+    });
     window.location.href = url + "&prompt=consent";
-  }, []);
+  }, [config]);
 
   const signOut = useCallback(() => {
     window.localStorage.removeItem(AUTH_STORAGE_KEY);
@@ -127,7 +146,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ oauth, isAuthAvailable, signIn, signOut }}>
+    <AuthContext.Provider
+      value={{
+        oauth,
+        isAuthAvailable: !!config,
+        signIn,
+        signOut,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Why

After deploying #71 the Sign-in button never appears on https://huggingface.co/spaces/lerobot/visualize_dataset.

Root cause: HF Spaces only auto-injects `window.huggingface.variables` for **static** Spaces. **Docker Spaces** (which this one is — `sdk: docker`) get `OAUTH_CLIENT_ID` / `OAUTH_SCOPES` as container env vars but no client-side global, so the gate

```ts
!!window.huggingface?.variables?.OAUTH_CLIENT_ID
```

was always false on the deployed Space and the button hid itself.

## How

- New `/api/auth/config` route returns `{ enabled, clientId, scopes }` from server env (`force-dynamic` so it's read at request time, not baked at build time).
- `AuthProvider` fetches the config on mount; uses it to gate the button (`isAuthAvailable`) and to pass `clientId` explicitly to `oauthLoginUrl({ clientId, scopes })` instead of relying on the missing `window.huggingface` global.
- The `OAUTH_CLIENT_ID` is a **public** client identifier — exposing it via API is fine. The `OAUTH_CLIENT_SECRET` stays server-side; only `/api/proxy` ever holds the user's access token (via the HttpOnly cookie set by `/api/auth/session`).

## Test plan
- [x] `bun run validate` passes
- [x] `bun run build` — `/api/auth/config` route registered
- [ ] After deploy: Sign-in button appears on the home page
- [ ] Button still **doesn't** appear in local dev (no `OAUTH_CLIENT_ID` env var → `enabled: false`)
- [ ] OAuth flow completes; private dataset metadata + parquet + video all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)