### PR TITLE
fix(auth): hf_access_token cookie needs SameSite=None + Partitioned for iframe

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -21,11 +21,20 @@ export async function POST(req: NextRequest) {
     return new NextResponse("Empty token", { status: 400 });
   }
 
+  // The Space is iframed inside huggingface.co/spaces/<owner>/<name>, so the
+  // top-level site differs from the cookie's site (*.hf.space). SameSite=Lax
+  // would block the cookie on subresource requests like <video> in that
+  // cross-site embedding context, which is exactly when we need it. Use
+  // SameSite=None + Secure + Partitioned (CHIPS) so the cookie rides along
+  // on subresource requests inside the iframe while remaining isolated to
+  // the (top-frame, this-domain) pair.
   const res = new NextResponse(null, { status: 204 });
+  const isProd = process.env.NODE_ENV === "production";
   res.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    secure: isProd,
+    sameSite: isProd ? "none" : "lax",
+    partitioned: isProd,
     path: "/",
     maxAge: COOKIE_MAX_AGE_SECONDS,
   });
@@ -33,7 +42,19 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE() {
+  // To clear a Partitioned cookie, the clearing Set-Cookie must include the
+  // Partitioned attribute too — otherwise it lands in a different cookie
+  // jar than the one we're trying to clear. Mirror the same attributes used
+  // when setting it, with maxAge=0 so it expires immediately.
   const res = new NextResponse(null, { status: 204 });
-  res.cookies.delete(COOKIE_NAME);
+  const isProd = process.env.NODE_ENV === "production";
+  res.cookies.set(COOKIE_NAME, "", {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: isProd ? "none" : "lax",
+    partitioned: isProd,
+    path: "/",
+    maxAge: 0,
+  });
   return res;
 }


### PR DESCRIPTION
## Why

Videos still don't load on the deployed Space when signed-in to a private dataset. The proxy code itself is correct — verified against the deployed `/api/proxy/...` route with a curl-set cookie, both range requests and full GETs work. The bug is one layer up: **the browser doesn't send the `hf_access_token` cookie on the `<video>` request at all**.

The Space is iframed inside `huggingface.co/spaces/<owner>/<name>`, so:
- Top-level site: `huggingface.co`
- Cookie's site: `*.hf.space`

These are different sites, so any subresource request originating in the iframe — including `<video src="/api/proxy/…">` — counts as a **cross-site context**. With `SameSite=Lax` the browser refuses to attach the cookie. The proxy receives the request without auth → forwards to HF without the bearer token → HF returns 404 for private repos. Public proxy traffic still works because it doesn't need the token.

## How

Switch to `SameSite=None; Secure; Partitioned` (CHIPS) in production:

| attr | reason |
| ---- | ------ |
| `SameSite=None` | required to send the cookie in cross-site iframe context |
| `Secure` | required by browsers when `SameSite=None` |
| `Partitioned` | scopes the cookie to the `(huggingface.co, *.hf.space)` frame pair so it's properly isolated rather than a plain third-party cookie |

Local dev keeps `SameSite=Lax` (no iframe, no HTTPS) so cookies still work without `Secure`.

`DELETE` mirrors the same attributes — browsers won't clear a Partitioned cookie with a Set-Cookie that lacks the `Partitioned` attribute.

## Verified

```
$ NODE_ENV=production bun run start &
$ curl -sI -X POST -H "Authorization: Bearer xxx" /api/auth/session
HTTP/1.1 204 No Content
set-cookie: hf_access_token=xxx; ...; Secure; HttpOnly; SameSite=none; Partitioned

$ curl -sI -X DELETE /api/auth/session
HTTP/1.1 204 No Content
set-cookie: hf_access_token=; Max-Age=0; Secure; HttpOnly; SameSite=none; Partitioned
```

## Test plan
- [x] `bun run validate` + `bun run build` pass
- [x] Set-Cookie shape verified in prod-mode local server
- [ ] After deploy: sign in → load a private dataset → videos play (and seek)
- [ ] Sign out → cookie cleared → private dataset videos 404 again
- [ ] Public datasets still play signed-in and signed-out (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)