### PR TITLE
feat(auth): include user token on quicksearch API call

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, useCallback, Suspense } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
+import { authHeaders } from "@/utils/auth";
 
 export default function Home() {
   return (
@@ -87,7 +88,7 @@ function HomeInner() {
       try {
         const res = await fetch(
           `https://huggingface.co/api/quicksearch?q=${encodeURIComponent(query)}&type=dataset`,
-          { cache: "no-store" },
+          { cache: "no-store", headers: authHeaders() },
         );
         const data = await res.json();
         const ids: string[] = (


### PR DESCRIPTION
## Summary
Thread `authHeaders()` through the homepage quicksearch fetch so signed-in users see their own private datasets in the search dropdown. Same pattern as `fetchJson` / `fetchParquetFile`; no-op when anonymous.

## Test plan
- [x] \`bun run validate\` passes
- [ ] After deploy, signed-in: type a private dataset name in the search box → it appears in the dropdown
- [ ] Signed-out: public-only results (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)