### PR TITLE
design(auth 1/9): ghost variant on the home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -284,7 +284,7 @@ function HomeInner() {
         </form>
 
         <div className="mt-3">
-          <HfAuthButton />
+          <HfAuthButton variant="ghost" />
         </div>
 
         {/* Example Datasets */}

--- a/src/components/hf-auth-button.tsx
+++ b/src/components/hf-auth-button.tsx
@@ -6,7 +6,18 @@ import { useAuth } from "@/context/auth-context";
 const SIGNIN_BADGE_URL =
   "https://huggingface.co/datasets/huggingface/badges/resolve/main/sign-in-with-huggingface-sm-dark.svg";
 
-export default function HfAuthButton() {
+// `badge` — the official HF brand badge. Use as a strong invitation when the
+//           auth path is itself the page's headline action.
+// `ghost`  — a quiet inline cyan link, sized to the surrounding body copy.
+//           Use when auth is a secondary affordance next to a primary CTA
+//           (e.g. the home page's search bar).
+type Variant = "badge" | "ghost";
+
+interface HfAuthButtonProps {
+  variant?: Variant;
+}
+
+export default function HfAuthButton({ variant = "badge" }: HfAuthButtonProps) {
   const { oauth, isAuthAvailable, signIn, signOut } = useAuth();
 
   if (!isAuthAvailable) return null;
@@ -36,6 +47,22 @@ export default function HfAuthButton() {
           Sign out
         </button>
       </div>
+    );
+  }
+
+  if (variant === "ghost") {
+    return (
+      <button
+        onClick={signIn}
+        title="Sign in to access your private datasets"
+        className="cursor-pointer inline-flex items-center gap-1.5 text-[11px] tracking-wide text-cyan-300/80 hover:text-cyan-200 transition-colors"
+      >
+        <span aria-hidden>🤗</span>
+        <span>Sign in for private datasets</span>
+        <span aria-hidden className="opacity-60">
+          →
+        </span>
+      </button>
     );
   }
 


### PR DESCRIPTION
First of nine sequential design refinements on the OAuth UI.

## Why
The HF brand badge competes with the search bar in the centered hero stack. Five centered stripes (H1, subtitle, search, badge, examples, CTA) all reading as CTAs makes the hierarchy muddy.

## What
- Adds a `variant` prop to `<HfAuthButton>`. Default is `badge` (existing brand image); new `ghost` variant is an inline cyan text affordance: 🤗 + "Sign in for private datasets →".
- Home page now renders `variant="ghost"` so the auth path reads as a quiet alt-affordance next to the search rather than a fourth CTA.
- Explore + episode pages keep the default `badge` variant for now.

## Test plan
- `bun run validate` passes
- After deploy: home page shows the cyan ghost link below the search input
- Other pages unchanged