### PR TITLE
design(auth 2/9): drop redundant tail next to the brand badge

### DIFF
--- a/src/components/hf-auth-button.tsx
+++ b/src/components/hf-auth-button.tsx
@@ -69,8 +69,9 @@ export default function HfAuthButton({ variant = "badge" }: HfAuthButtonProps) {
   return (
     <button
       onClick={signIn}
-      title="Sign in to access your private datasets"
-      className="cursor-pointer inline-flex items-center gap-1.5 rounded-md transition-opacity hover:opacity-90"
+      title="Sign in with Hugging Face to access your private datasets"
+      aria-label="Sign in with Hugging Face to access your private datasets"
+      className="cursor-pointer inline-flex items-center rounded-md transition-opacity hover:opacity-90"
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
@@ -79,9 +80,6 @@ export default function HfAuthButton({ variant = "badge" }: HfAuthButtonProps) {
         height={24}
         className="h-6 w-auto"
       />
-      <span className="text-[11px] text-slate-300/80">
-        to access private datasets
-      </span>
     </button>
   );
 }


### PR DESCRIPTION
Second of nine sequential design refinements.

## Why
The HF badge SVG already says "Sign in with Hugging Face" inside the badge. Adding a "to access private datasets" text tail next to it duplicated the message in a quieter font and created a Frankenstein two-affordance object — saturated brand image + pale 11px caption.

## What
- Remove the trailing `<span>to access private datasets</span>`.
- Move the explanatory copy into the `title` tooltip + `aria-label` so screen readers and hover users still get it.
- Badge now stands alone as a single cohesive control.

## Test plan
- `bun run validate` passes
- Hovering the badge shows the full tooltip
- Screen reader announces "Sign in with Hugging Face to access your private datasets"