### PR TITLE
design(auth 3/9): tab variant on the episode viewer's tab bar

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -532,7 +532,7 @@ function EpisodeViewerInner({
           title="Dataset quality diagnostics (powered by lerobot-doctor)"
         />
         <div className="ml-auto pr-3">
-          <HfAuthButton />
+          <HfAuthButton variant="tab" />
         </div>
       </div>
 

--- a/src/components/hf-auth-button.tsx
+++ b/src/components/hf-auth-button.tsx
@@ -11,7 +11,10 @@ const SIGNIN_BADGE_URL =
 // `ghost`  — a quiet inline cyan link, sized to the surrounding body copy.
 //           Use when auth is a secondary affordance next to a primary CTA
 //           (e.g. the home page's search bar).
-type Variant = "badge" | "ghost";
+// `tab`    — uppercase tracked text styled to match a tab strip; pairs with
+//           the episode viewer's tab bar so the auth control reads as part
+//           of the same register.
+type Variant = "badge" | "ghost" | "tab";
 
 interface HfAuthButtonProps {
   variant?: Variant;
@@ -62,6 +65,19 @@ export default function HfAuthButton({ variant = "badge" }: HfAuthButtonProps) {
         <span aria-hidden className="opacity-60">
           →
         </span>
+      </button>
+    );
+  }
+
+  if (variant === "tab") {
+    return (
+      <button
+        onClick={signIn}
+        title="Sign in to access your private datasets"
+        className="cursor-pointer inline-flex items-center gap-1.5 px-3 text-[11px] font-medium tracking-wide uppercase text-slate-400 hover:text-cyan-300 transition-colors"
+      >
+        <span aria-hidden>🤗</span>
+        <span>Sign in</span>
       </button>
     );
   }


### PR DESCRIPTION
Third of nine sequential design refinements.

## Why
The episode viewer's tab bar uses uppercase tracking-wide text with cyan underline accents — a quiet, editorial register. Dropping the saturated HF brand badge on the right end was a visual mismatch.

## What
- New `tab` variant on `<HfAuthButton>` styled to match the tab strip (uppercase, `text-[11px] font-medium tracking-wide`, slate-400 → cyan-300 hover, 🤗 inline mark, no badge image).
- Episode viewer's tab bar now uses `<HfAuthButton variant="tab" />`.

## Test plan
- `bun run validate` passes
- After deploy: the right end of the episode tab bar shows a "🤗 SIGN IN" link that visually matches the other tabs