### PR TITLE
design(auth 5/9): bump avatar from 14px to 20px

### DIFF
--- a/src/components/hf-auth-button.tsx
+++ b/src/components/hf-auth-button.tsx
@@ -44,9 +44,9 @@ export default function HfAuthButton({ variant = "badge" }: HfAuthButtonProps) {
           <img
             src={avatar}
             alt=""
-            width={14}
-            height={14}
-            className="rounded-full"
+            width={20}
+            height={20}
+            className="rounded-full ring-1 ring-white/10"
           />
         )}
         <span className="tabular max-w-[8rem] truncate">{name}</span>


### PR DESCRIPTION
Fifth of nine sequential design refinements.

## Why
14×14 avatar reads as a dot, not a face. The user's HF profile picture is the strongest visual confirmation that the right account is signed in — it deserves to be legible.

## What
- Avatar grows from 14px → 20px. Lands inside the 24px pill with 2px breathing room top/bottom.
- Adds \`ring-1 ring-white/10\` so the circle has a defined edge against the pill's translucent surface.

## Test plan
- \`bun run validate\` passes
- After deploy: signed-in pill shows a recognizable profile picture instead of a dot