### PR TITLE
fix(video 3/12): proxy returns 502 on upstream fetch failure

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -86,12 +86,21 @@ export async function GET(
     if (v) headers.set(h, v);
   }
 
-  const upstream = await fetch(upstreamUrl, {
-    method: "GET",
-    headers,
-    redirect: "follow",
-    cache: "no-store",
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: "GET",
+      headers,
+      redirect: "follow",
+      cache: "no-store",
+    });
+  } catch (err) {
+    // Network error reaching huggingface.co (DNS, reset, etc.). The native
+    // <video> turns this into a generic load error with no details, so log
+    // server-side and return a useful 502 the client can surface in devtools.
+    console.error("[proxy] upstream fetch failed", err);
+    return new Response("Bad gateway: upstream fetch failed", { status: 502 });
+  }
 
   const respHeaders = new Headers();
   for (const h of FORWARD_RESPONSE_HEADERS) {
@@ -121,12 +130,18 @@ export async function HEAD(
   const token = req.cookies.get(COOKIE_NAME)?.value;
   if (token) headers.set("authorization", `Bearer ${token}`);
 
-  const upstream = await fetch(upstreamUrl, {
-    method: "HEAD",
-    headers,
-    redirect: "follow",
-    cache: "no-store",
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: "HEAD",
+      headers,
+      redirect: "follow",
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("[proxy] upstream HEAD failed", err);
+    return new Response(null, { status: 502 });
+  }
 
   const respHeaders = new Headers();
   for (const h of FORWARD_RESPONSE_HEADERS) {


### PR DESCRIPTION
Third of twelve sequential video / sync fixes.

## Why
Network errors reaching huggingface.co (DNS, reset, etc.) bubbled out of the route handler and Next returned a generic 500 with an HTML error page. The native \`<video>\` element treats that as a fatal load error with no useful detail.

## What
- Wrap the GET / HEAD upstream fetches in try/catch.
- Log server-side with context.
- Return a clean 502 Bad Gateway.

The client can now distinguish "proxy could not reach HF" from "HF returned a real status" (4xx/5xx are still forwarded as-is).

## Test plan
- \`bun run validate\` passes
- After deploy: pulling the network mid-request surfaces a 502 in devtools instead of a 500-page HTML body