### PR TITLE
fix(video 5/12): explicit "video" vs "external" seek source

### DIFF
--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -24,7 +24,13 @@ export const SimpleVideosPlayer = ({
   videosInfo,
   onVideosReady,
 }: VideoPlayerProps) => {
-  const { currentTime, setCurrentTime, isPlaying, setIsPlaying } = useTime();
+  const {
+    currentTime,
+    setCurrentTime,
+    externalSeekVersion,
+    isPlaying,
+    setIsPlaying,
+  } = useTime();
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
   const [hiddenVideos, setHiddenVideos] = React.useState<string[]>([]);
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);
@@ -37,9 +43,10 @@ export const SimpleVideosPlayer = ({
     (video) => !hiddenSet.has(video.filename),
   );
 
-  // Tracks the last time value set by the primary video's onTimeUpdate.
-  // If currentTime differs from this, an external source (slider/chart click) changed it.
-  const lastVideoTimeRef = useRef(0);
+  // Last externalSeekVersion we observed in the sync effect. When the
+  // context's version moves past this, an external seek happened and we
+  // need to drive every video to the new position.
+  const lastSeekVersionRef = useRef(externalSeekVersion);
 
   // Mirror firstVisibleIdx into a ref so the videos-ready effect doesn't have
   // to depend on it. If it did, hiding the first camera would tear the whole
@@ -162,19 +169,19 @@ export const SimpleVideosPlayer = ({
     });
   }, [isPlaying, videosReady, hiddenSet, videosInfo]);
 
-  // Sync all video times when currentTime changes.
-  // For the primary video, only seek when the change came from an external source
-  // (slider drag, chart click, etc.) — detected by comparing against lastVideoTimeRef.
+  // Drive every video to currentTime on external seeks (slider drag, chart
+  // click, loop reset). The version-based check replaces a 0.3s heuristic
+  // that misfired when a network stall produced a >0.3s timeupdate jump
+  // and incorrectly classified it as a user seek — causing every camera to
+  // re-seek, which itself stalled them in a feedback spiral.
   useEffect(() => {
     if (!videosReady) return;
-
-    const isExternalSeek =
-      Math.abs(currentTime - lastVideoTimeRef.current) > 0.3;
+    if (externalSeekVersion === lastSeekVersionRef.current) return;
+    lastSeekVersionRef.current = externalSeekVersion;
 
     videoRefs.current.forEach((video, index) => {
       if (!video) return;
       if (hiddenSet.has(videosInfo[index].filename)) return;
-      if (index === firstVisibleIdx && !isExternalSeek) return;
 
       const info = videosInfo[index];
       let targetTime = currentTime;
@@ -189,9 +196,11 @@ export const SimpleVideosPlayer = ({
         video.currentTime = targetTime;
       }
     });
-  }, [currentTime, videosInfo, videosReady, hiddenSet, firstVisibleIdx]);
+  }, [externalSeekVersion, currentTime, videosInfo, videosReady, hiddenSet]);
 
-  // Stable per-index timeupdate handlers avoid findIndex scan on every event
+  // Stable per-index timeupdate handlers avoid findIndex scan on every event.
+  // Tagged "video" so the context doesn't bump externalSeekVersion — the
+  // sync effect treats this as a status report, not a seek command.
   const makeTimeUpdateHandler = useCallback(
     (index: number) => {
       return () => {
@@ -203,8 +212,7 @@ export const SimpleVideosPlayer = ({
         if (info.isSegmented) {
           globalTime = video.currentTime - (info.segmentStart || 0);
         }
-        lastVideoTimeRef.current = globalTime;
-        setCurrentTime(globalTime);
+        setCurrentTime(globalTime, "video");
       };
     },
     [videosInfo, setCurrentTime],

--- a/src/context/time-context.tsx
+++ b/src/context/time-context.tsx
@@ -7,9 +7,24 @@ import React, {
   useEffect,
 } from "react";
 
+// `external` (default) — user-initiated seek (slider drag, chart click,
+//                        loop boundary reset). Bumps `externalSeekVersion`
+//                        so sync effects know to drive every video to the
+//                        new position.
+// `video`              — the primary video reporting its own currentTime
+//                        via timeupdate. Does NOT bump the version; the
+//                        sync effect should treat the change as a status
+//                        report, not a command.
+type TimeUpdateSource = "external" | "video";
+
 type TimeContextType = {
   currentTime: number;
-  setCurrentTime: (t: number) => void;
+  setCurrentTime: (t: number, source?: TimeUpdateSource) => void;
+  // Monotonically increasing counter that bumps on every `external` seek.
+  // Sync effects compare the current value against a stored ref to detect
+  // user-initiated seeks without relying on heuristics like "did the time
+  // jump by more than 0.3s".
+  externalSeekVersion: number;
   subscribe: (cb: (t: number) => void) => () => void;
   isPlaying: boolean;
   setIsPlaying: React.Dispatch<React.SetStateAction<boolean>>;
@@ -34,6 +49,7 @@ export const TimeProvider: React.FC<{
   const [currentTime, setCurrentTimeState] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [duration, setDuration] = useState(initialDuration);
+  const [externalSeekVersion, setExternalSeekVersion] = useState(0);
   const listeners = useRef<Set<(t: number) => void>>(new Set());
 
   // Keep the authoritative time in a ref so subscribers and sync effects
@@ -42,24 +58,31 @@ export const TimeProvider: React.FC<{
   const rafId = useRef<number | null>(null);
   const lastRenderTime = useRef(0);
 
-  const updateTime = useCallback((t: number) => {
-    timeRef.current = t;
-    listeners.current.forEach((fn) => fn(t));
+  const updateTime = useCallback(
+    (t: number, source: TimeUpdateSource = "external") => {
+      timeRef.current = t;
+      listeners.current.forEach((fn) => fn(t));
 
-    // Throttle React state updates — during playback, timeupdate fires ~4×/sec
-    // per video. Coalescing into rAF + a minimum interval avoids cascading
-    // re-renders across PlaybackBar, charts, etc.
-    if (rafId.current === null) {
-      rafId.current = requestAnimationFrame(() => {
-        rafId.current = null;
-        const now = performance.now();
-        if (now - lastRenderTime.current >= TIME_RENDER_THROTTLE_MS) {
-          lastRenderTime.current = now;
-          setCurrentTimeState(timeRef.current);
-        }
-      });
-    }
-  }, []);
+      if (source === "external") {
+        setExternalSeekVersion((v) => v + 1);
+      }
+
+      // Throttle React state updates — during playback, timeupdate fires ~4×/sec
+      // per video. Coalescing into rAF + a minimum interval avoids cascading
+      // re-renders across PlaybackBar, charts, etc.
+      if (rafId.current === null) {
+        rafId.current = requestAnimationFrame(() => {
+          rafId.current = null;
+          const now = performance.now();
+          if (now - lastRenderTime.current >= TIME_RENDER_THROTTLE_MS) {
+            lastRenderTime.current = now;
+            setCurrentTimeState(timeRef.current);
+          }
+        });
+      }
+    },
+    [],
+  );
 
   // Flush any pending rAF on unmount
   useEffect(() => {
@@ -85,6 +108,7 @@ export const TimeProvider: React.FC<{
       value={{
         currentTime,
         setCurrentTime: updateTime,
+        externalSeekVersion,
         subscribe,
         isPlaying,
         setIsPlaying,


### PR DESCRIPTION
Fifth of twelve sequential video / sync fixes.

## Why
The 0.3s heuristic for detecting external seeks was fragile — a network stall during playback could produce a >0.3s timeupdate jump that was misclassified as a user seek, causing every camera to re-seek, which itself stalled them in a feedback spiral.

## What
- TimeContext exposes \`setCurrentTime(t, source?: "video" | "external")\` and an \`externalSeekVersion: number\` counter.
- \`source = "external"\` (default) bumps the version. Slider drags, chart clicks, loop boundary resets, and all existing call sites stay correct without changes.
- \`source = "video"\` (only the primary video's \`onTimeUpdate\` handler) does NOT bump the version.
- The videos-player's sync effect now triggers on \`externalSeekVersion\` changes, detected via a ref. No more heuristic.

## Test plan
- \`bun run validate\` passes
- After deploy: slider drag still seeks every camera; chart click still seeks; loop boundary still resets the slider; mid-playback stalls no longer cause cascading re-seeks