### PR TITLE
fix(video 7/12): handle already-loaded videos when wiring listeners

### DIFF
--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -149,11 +149,25 @@ export const SimpleVideosPlayer = ({
 
       video.addEventListener("timeupdate", handleTimeUpdate);
       if (handlePlay) video.addEventListener("play", handlePlay);
-      if (handleLoadedData)
-        video.addEventListener("loadeddata", handleLoadedData);
       if (handleEnded) video.addEventListener("ended", handleEnded);
-      if (!info.isSegmented) {
-        video.addEventListener("canplaythrough", checkReady, { once: true });
+
+      // Already-loaded videos (cached or fast network) will never re-fire
+      // canplaythrough / loadeddata after we attach the listener — so check
+      // readyState synchronously and mark ready in a microtask. Without this,
+      // checkReady wouldn't be called and only the 10s fallback timeout would
+      // eventually unfreeze the UI.
+      if (info.isSegmented && handleLoadedData) {
+        if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+          queueMicrotask(handleLoadedData);
+        } else {
+          video.addEventListener("loadeddata", handleLoadedData);
+        }
+      } else if (!info.isSegmented) {
+        if (video.readyState >= HTMLMediaElement.HAVE_ENOUGH_DATA) {
+          queueMicrotask(checkReady);
+        } else {
+          video.addEventListener("canplaythrough", checkReady, { once: true });
+        }
       }
 
       videoEventCleanup.set(video, () => {


### PR DESCRIPTION
Seventh of twelve sequential video / sync fixes.

## Why
If a video is already past \`HAVE_CURRENT_DATA\` (segmented) or \`HAVE_ENOUGH_DATA\` (non-segmented) by the time the videos-ready effect runs — common when the resource is cached or the network is fast — \`loadeddata\` / \`canplaythrough\` won't re-fire. The listener was attached but never invoked, \`readyCount\` stayed below \`videosInfo.length\`, and the UI sat frozen for 10s until the fallback timeout finally fired \`markReady\`.

## What
- Synchronously check \`video.readyState\` when wiring listeners.
- If already at the required level, schedule the handler via \`queueMicrotask\` (preserves the existing async ordering — handlers don't run during the same task as the effect setup).
- Otherwise fall back to \`addEventListener\` as before.

## Test plan
- \`bun run validate\` passes
- After deploy: cached / instant-load videos resolve readiness immediately instead of after 10s