### PR TITLE
fix(video 10/12): clear enlarged state when its video is hidden

### DIFF
--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -339,9 +339,16 @@ export const SimpleVideosPlayer = ({
                   <button
                     title="Hide Video"
                     className="p-1 rounded text-slate-500 hover:text-slate-200 hover:bg-white/5 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
-                    onClick={() =>
-                      setHiddenVideos((prev) => [...prev, info.filename])
-                    }
+                    onClick={() => {
+                      setHiddenVideos((prev) => [...prev, info.filename]);
+                      // If the user hid the camera that was enlarged, clear
+                      // the enlarged state too — otherwise it stays pointed
+                      // at the now-hidden filename and pops back to fullscreen
+                      // the moment the user un-hides it.
+                      if (enlargedVideo === info.filename) {
+                        setEnlargedVideo(null);
+                      }
+                    }}
                     disabled={
                       videosInfo.filter(
                         (v) => !hiddenVideos.includes(v.filename),


### PR DESCRIPTION
Tenth of twelve sequential video / sync fixes.

## Why
Enlarge camera A, then hide it (only possible when ≥2 cameras are visible). \`enlargedVideo\` stayed pointing at A. Un-hide A and it pops back into fullscreen, which is rarely the intent.

## What
Clear \`enlargedVideo\` in the hide handler when the hidden filename matches the enlarged one.

## Test plan
- \`bun run validate\` passes
- After deploy: enlarge → hide → un-hide → no fullscreen surprise