### PR TITLE
fix(video 12/12): rename context setCurrentTime → seek

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -335,7 +335,7 @@ function EpisodeViewerInner({
   };
 
   // Use context for time sync
-  const { currentTime, setCurrentTime, setIsPlaying, isPlaying } = useTime();
+  const { currentTime, seek, setIsPlaying, isPlaying } = useTime();
 
   // URDFViewer episode changer and play toggle — populated by URDFViewer on mount
   const urdfChangerRef = useRef<((ep: number) => void) | undefined>(undefined);
@@ -383,10 +383,10 @@ function EpisodeViewerInner({
     if (timeParam) {
       const timeValue = parseFloat(timeParam);
       if (!isNaN(timeValue)) {
-        setCurrentTime(timeValue);
+        seek(timeValue);
       }
     }
-  }, [searchParams, setCurrentTime]);
+  }, [searchParams, seek]);
 
   // sync with parent window hf.co/spaces
   useEffect(() => {

--- a/src/components/data-recharts.tsx
+++ b/src/components/data-recharts.tsx
@@ -155,7 +155,7 @@ const SingleDataGraph = React.memo(
     setHoveredTime: (t: number | null) => void;
     tall?: boolean;
   }) => {
-    const { currentTime, setCurrentTime } = useTime();
+    const { currentTime, seek } = useTime();
     const flattenRow = useCallback(
       (row: Record<string, number | Record<string, number>>, prefix = "") => {
         const result: Record<string, number> = {};
@@ -246,7 +246,7 @@ const SingleDataGraph = React.memo(
       data: { activePayload?: { payload: { timestamp: number } }[] } | null,
     ) => {
       if (data?.activePayload?.length) {
-        setCurrentTime(data.activePayload[0].payload.timestamp);
+        seek(data.activePayload[0].payload.timestamp);
       }
     };
 

--- a/src/components/playback-bar.tsx
+++ b/src/components/playback-bar.tsx
@@ -11,8 +11,7 @@ import {
 } from "react-icons/fa";
 
 const PlaybackBar: React.FC = () => {
-  const { duration, isPlaying, setIsPlaying, currentTime, setCurrentTime } =
-    useTime();
+  const { duration, isPlaying, setIsPlaying, currentTime, seek } = useTime();
 
   const sliderActiveRef = React.useRef(false);
   const wasPlayingRef = React.useRef(false);
@@ -29,7 +28,7 @@ const PlaybackBar: React.FC = () => {
     const t = Number(e.target.value);
     setSliderValue(t);
     // Seek videos immediately while dragging (no debounce)
-    setCurrentTime(t);
+    seek(t);
   };
 
   const handleSliderMouseDown = () => {
@@ -41,7 +40,7 @@ const PlaybackBar: React.FC = () => {
   const handleSliderMouseUp = () => {
     sliderActiveRef.current = false;
     // Final seek to exact slider position
-    setCurrentTime(sliderValue);
+    seek(sliderValue);
     if (wasPlayingRef.current) {
       setIsPlaying(true);
     }
@@ -51,7 +50,7 @@ const PlaybackBar: React.FC = () => {
     <div className="sticky bottom-0 mt-auto w-full max-w-4xl mx-auto flex items-center gap-3 panel-raised bg-[var(--surface-0)]/90 backdrop-blur px-3 py-2">
       <button
         title="Jump backward 5 seconds"
-        onClick={() => setCurrentTime(Math.max(0, currentTime - 5))}
+        onClick={() => seek(Math.max(0, currentTime - 5))}
         className="hidden md:flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:text-slate-100 hover:bg-white/5 transition-colors"
       >
         <FaBackward size={14} />
@@ -67,14 +66,14 @@ const PlaybackBar: React.FC = () => {
       </button>
       <button
         title="Jump forward 5 seconds"
-        onClick={() => setCurrentTime(Math.min(duration, currentTime + 5))}
+        onClick={() => seek(Math.min(duration, currentTime + 5))}
         className="hidden md:flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:text-slate-100 hover:bg-white/5 transition-colors"
       >
         <FaForward size={14} />
       </button>
       <button
         title="Rewind from start"
-        onClick={() => setCurrentTime(0)}
+        onClick={() => seek(0)}
         className="hidden md:flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:text-slate-100 hover:bg-white/5 transition-colors"
       >
         <FaUndoAlt size={14} />

--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -24,13 +24,8 @@ export const SimpleVideosPlayer = ({
   videosInfo,
   onVideosReady,
 }: VideoPlayerProps) => {
-  const {
-    currentTime,
-    setCurrentTime,
-    externalSeekVersion,
-    isPlaying,
-    setIsPlaying,
-  } = useTime();
+  const { currentTime, seek, externalSeekVersion, isPlaying, setIsPlaying } =
+    useTime();
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
   const [hiddenVideos, setHiddenVideos] = React.useState<string[]>([]);
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);
@@ -101,7 +96,7 @@ export const SimpleVideosPlayer = ({
       });
       // Update the slider as a status report — don't bump externalSeekVersion
       // since we already drove every video to its target.
-      setCurrentTime(0, "video");
+      seek(0, "video");
     };
 
     videoRefs.current.forEach((video, index) => {
@@ -135,7 +130,7 @@ export const SimpleVideosPlayer = ({
           if (info.isSegmented) {
             globalTime = video.currentTime - (info.segmentStart ?? 0);
           }
-          setCurrentTime(globalTime, "video");
+          seek(globalTime, "video");
         }
       };
 
@@ -221,7 +216,7 @@ export const SimpleVideosPlayer = ({
     // firstVisibleIdx intentionally omitted — we read it via ref so hiding
     // the first camera doesn't reset readiness (see the comment near
     // firstVisibleIdxRef above).
-  }, [videosInfo, onVideosReady, setIsPlaying, setCurrentTime]);
+  }, [videosInfo, onVideosReady, setIsPlaying, seek]);
 
   // Handle play/pause — skip hidden videos
   useEffect(() => {

--- a/src/components/videos-player.tsx
+++ b/src/components/videos-player.tsx
@@ -19,7 +19,7 @@ export const VideosPlayer = ({
   videosInfo,
   onVideosReady,
 }: VideoPlayerProps) => {
-  const { currentTime, setCurrentTime, isPlaying, setIsPlaying } = useTime();
+  const { currentTime, seek, isPlaying, setIsPlaying } = useTime();
   const videoRefs = useRef<HTMLVideoElement[]>([]);
   const [hiddenVideos, setHiddenVideos] = useState<string[]>([]);
 
@@ -184,14 +184,14 @@ export const VideosPlayer = ({
           const segmentStart = videoInfo.segmentStart || 0;
           const globalTime = Math.max(0, video.currentTime - segmentStart);
           lastVideoTimeRef.current = globalTime;
-          setCurrentTime(globalTime);
+          seek(globalTime);
         } else {
           lastVideoTimeRef.current = video.currentTime;
-          setCurrentTime(video.currentTime);
+          seek(video.currentTime);
         }
       };
     },
-    [videosInfo, setCurrentTime],
+    [videosInfo, seek],
   );
 
   // Handle video ready and setup segmentation

--- a/src/context/time-context.tsx
+++ b/src/context/time-context.tsx
@@ -19,7 +19,7 @@ type TimeUpdateSource = "external" | "video";
 
 type TimeContextType = {
   currentTime: number;
-  setCurrentTime: (t: number, source?: TimeUpdateSource) => void;
+  seek: (t: number, source?: TimeUpdateSource) => void;
   // Monotonically increasing counter that bumps on every `external` seek.
   // Sync effects compare the current value against a stored ref to detect
   // user-initiated seeks without relying on heuristics like "did the time
@@ -107,7 +107,7 @@ export const TimeProvider: React.FC<{
     <TimeContext.Provider
       value={{
         currentTime,
-        setCurrentTime: updateTime,
+        seek: updateTime,
         externalSeekVersion,
         subscribe,
         isPlaying,


### PR DESCRIPTION
Final of twelve sequential video / sync fixes.

## Why
The context-exposed \`setCurrentTime\` was actually \`updateTime\` — a rAF-batched commit, not a useState setter. The name suggested state mutation but the semantic is "drive everyone (videos, charts, slider) to this time" — a seek.

## What
- Rename the context member to \`seek\` (and the \`TimeContextType\` field to match).
- Update every call site: \`episode-viewer.tsx\`, \`simple-videos-player.tsx\`, \`playback-bar.tsx\`, \`videos-player.tsx\`, \`data-recharts.tsx\`.
- Internal \`setCurrentTimeState\` (the actual useState setter inside the provider) keeps its name.

Cosmetic only — same runtime behavior.

## Test plan
- \`bun run validate\` passes