### PR TITLE
fix(video): videos stuck on first frame after PR 7

### DIFF
--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -54,6 +54,19 @@ export const SimpleVideosPlayer = ({
     firstVisibleIdxRef.current = firstVisibleIdx;
   }, [firstVisibleIdx]);
 
+  // Mirror onVideosReady into a ref for the same reason. Parents typically
+  // pass an inline arrow (`onVideosReady={() => setVideosReady(true)}`) which
+  // gets a new identity every render. Including it in the videos-ready
+  // effect's deps caused that effect to tear down + setup on every parent
+  // render. The setup branch then ran `queueMicrotask(handleLoadedData)` for
+  // every already-loaded video (true after the first load), seeking each
+  // back to segmentStart — videos got pinned on their first frame and never
+  // advanced.
+  const onVideosReadyRef = useRef(onVideosReady);
+  useEffect(() => {
+    onVideosReadyRef.current = onVideosReady;
+  }, [onVideosReady]);
+
   // Initialize video refs array
   useEffect(() => {
     videoRefs.current = videoRefs.current.slice(0, videosInfo.length);
@@ -69,7 +82,7 @@ export const SimpleVideosPlayer = ({
       if (resolved) return;
       resolved = true;
       setVideosReady(true);
-      onVideosReady?.();
+      onVideosReadyRef.current?.();
       setIsPlaying(true);
     };
 
@@ -216,7 +229,9 @@ export const SimpleVideosPlayer = ({
     // firstVisibleIdx intentionally omitted — we read it via ref so hiding
     // the first camera doesn't reset readiness (see the comment near
     // firstVisibleIdxRef above).
-  }, [videosInfo, onVideosReady, setIsPlaying, seek]);
+    // onVideosReady intentionally omitted — read via onVideosReadyRef so
+    // an inline parent prop doesn't tear this effect down on every render.
+  }, [videosInfo, setIsPlaying, seek]);
 
   // Handle play/pause — skip hidden videos
   useEffect(() => {


### PR DESCRIPTION
Regression bisect:
- PR 7 (fix/video-7-canplaythrough-cleanup) added \`queueMicrotask(handleLoadedData)\` for already-loaded videos.
- The parent passes \`onVideosReady={() => setVideosReady(true)}\` — a fresh inline arrow per render.
- The videos-ready \`useEffect\` listed \`onVideosReady\` in its deps, so it tore down + setup on every parent render.
- The setup branch's queueMicrotask path seeked every already-loaded video back to \`segmentStart\` (0 for episode 0).
- \`EpisodeViewerInner\` re-renders ~12.5×/sec (uses \`useTime\`, throttled state update fires that often during playback) → seek-to-0 fired ~12.5×/sec → playback pinned on the first frame.

## Fix
Mirror \`onVideosReady\` into a ref (same pattern as \`firstVisibleIdxRef\` from PR 1), drop it from the videos-ready effect's deps. The effect now only re-runs when \`videosInfo\` identity changes (i.e. episode change), which is what we actually want.

## Verified locally with chrome-devtools-mcp
On \`lerobot/high_quality_folding\` episode 0:
- before: currentTime stuck at 0.000–0.4 in a tight seek loop
- after: 4.78s → 22.52s in 3 seconds, all 3 cameras in lockstep