### PR TITLE
Support float64 numeric features in charts

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/__tests__/fetch-data.test.ts
+++ b/src/app/[org]/[dataset]/[episode]/__tests__/fetch-data.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, test } from "bun:test";
-import { computeColumnMinMax } from "@/app/[org]/[dataset]/[episode]/fetch-data";
+import {
+  computeColumnMinMax,
+  isChartableNumericFeature,
+} from "@/app/[org]/[dataset]/[episode]/fetch-data";
 import type { ChartRow } from "@/app/[org]/[dataset]/[episode]/fetch-data";
+
+// ---------------------------------------------------------------------------
+// Feature dtype detection
+// ---------------------------------------------------------------------------
+
+describe("isChartableNumericFeature", () => {
+  test("includes float64 vector features used by v2.1 LeRobot datasets", () => {
+    expect(
+      isChartableNumericFeature({
+        dtype: "float64",
+        shape: [43],
+      }),
+    ).toBe(true);
+  });
+
+  test("excludes videos and multidimensional numeric tensors from charts", () => {
+    expect(
+      isChartableNumericFeature({
+        dtype: "video",
+        shape: [480, 640, 3],
+      }),
+    ).toBe(false);
+    expect(
+      isChartableNumericFeature({
+        dtype: "float32",
+        shape: [1, 72],
+      }),
+    ).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // computeColumnMinMax

--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -23,6 +23,19 @@ import { bigIntToNumber } from "@/utils/typeGuards";
 import type { VideoInfo, AdjacentEpisodeVideos } from "@/types";
 
 const SERIES_NAME_DELIMITER = CHART_CONFIG.SERIES_NAME_DELIMITER;
+const CHARTABLE_NUMERIC_DTYPES = new Set([
+  "float16",
+  "float32",
+  "float64",
+  "int8",
+  "int16",
+  "int32",
+  "int64",
+  "uint8",
+  "uint16",
+  "uint32",
+  "uint64",
+]);
 
 export type CameraInfo = { name: string; width: number; height: number };
 
@@ -45,6 +58,16 @@ export type ColumnMinMax = {
   min: number;
   max: number;
 };
+
+export function isChartableNumericFeature(feature: {
+  dtype: string;
+  shape: number[];
+}): boolean {
+  return (
+    CHARTABLE_NUMERIC_DTYPES.has(feature.dtype.toLowerCase()) &&
+    feature.shape.length === 1
+  );
+}
 
 export type EpisodeLengthInfo = {
   episodeIndex: number;
@@ -495,10 +518,7 @@ async function getEpisodeDataV2(
 
   // Column data
   const columnNames = Object.entries(info.features)
-    .filter(
-      ([, value]) =>
-        ["float32", "int32"].includes(value.dtype) && value.shape.length === 1,
-    )
+    .filter(([, value]) => isChartableNumericFeature(value))
     .map(([key, { shape }]) => ({ key, length: shape[0] }));
 
   // Exclude specific columns
@@ -634,7 +654,8 @@ async function getEpisodeDataV2(
   const ignoredColumns = Object.entries(info.features)
     .filter(
       ([, value]) =>
-        ["float32", "int32"].includes(value.dtype) && value.shape.length > 1,
+        CHARTABLE_NUMERIC_DTYPES.has(value.dtype.toLowerCase()) &&
+        value.shape.length > 1,
     )
     .map(([key]) => key);
 
@@ -964,9 +985,7 @@ function processEpisodeDataForCharts(
   const columns: ColumnDef[] = Object.entries(info.features)
     .filter(
       ([key, value]) =>
-        ["float32", "int32"].includes(value.dtype) &&
-        value.shape.length === 1 &&
-        !excludedColumns.includes(key),
+        isChartableNumericFeature(value) && !excludedColumns.includes(key),
     )
     .map(([key, feature]) => {
       let column_names: unknown = feature.names;
@@ -1090,7 +1109,8 @@ function processEpisodeDataForCharts(
     ...Object.entries(info.features)
       .filter(
         ([, value]) =>
-          ["float32", "int32"].includes(value.dtype) && value.shape.length > 2, // Only ignore 3D+ data
+          CHARTABLE_NUMERIC_DTYPES.has(value.dtype.toLowerCase()) &&
+          value.shape.length > 2, // Only ignore 3D+ data
       )
       .map(([key]) => key),
     ...excludedColumns, // Also include the manually excluded columns

--- a/src/types/dataset.types.ts
+++ b/src/types/dataset.types.ts
@@ -7,7 +7,21 @@
 export type DatasetVersion = "v2.0" | "v2.1" | "v3.0";
 
 // Feature data types
-export type FeatureDType = "video" | "float32" | "int32" | "int64" | "bool";
+export type FeatureDType =
+  | "video"
+  | "float16"
+  | "float32"
+  | "float64"
+  | "int8"
+  | "int16"
+  | "int32"
+  | "int64"
+  | "uint8"
+  | "uint16"
+  | "uint32"
+  | "uint64"
+  | "bool"
+  | "boolean";
 
 // Video-specific feature
 export interface VideoFeature {
@@ -25,7 +39,7 @@ export interface VideoFeature {
 
 // Numeric feature (state, action, etc.)
 export interface NumericFeature {
-  dtype: "float32" | "int32" | "int64";
+  dtype: Exclude<FeatureDType, "video" | "bool" | "boolean">;
   shape: number[];
   names: string[] | { motors: string[] } | { [key: string]: string[] } | null;
   fps?: number;


### PR DESCRIPTION
## Summary

Adds support for `float64` numeric features in chart data.

This helps visualize v2.1 datasets exported from [GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl), where numeric observation vectors may be stored as `float64`.

## Validation

- `bun run format && bun run validate`