### PR TITLE
feat: lazy video transcode fallback for undecodable depth videos

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,14 @@ pip install -r requirements.txt
 uvicorn app:app --port 7861 --reload
 ```
 
+### Video transcoding dependency (optional)
+
+The video transcode endpoint (`/api/video/transcode`) uses
+[PyAV](https://pyav.org) (in-process FFmpeg bindings) — installed via
+`requirements.txt` as `av`. PyAV's wheels bundle FFmpeg, so there's no separate
+system install. If `av` is not installed, the endpoint returns HTTP 503 and the
+rest of the backend works normally.
+
 Then start the Next.js visualizer with the backend URL configured:
 
 ```bash
@@ -30,15 +38,60 @@ NEXT_PUBLIC_ANNOTATE_BACKEND_URL=http://127.0.0.1:7861 bun run dev
 
 ## API
 
-| Method | Path                                  | Purpose                                                              |
-| ------ | ------------------------------------- | -------------------------------------------------------------------- |
-| GET    | `/api/health`                         | Liveness + style catalog                                             |
-| POST   | `/api/dataset/load`                   | Cache + read a dataset's `meta/`                                     |
-| GET    | `/api/episodes/{ep}/atoms`            | Read saved atoms                                                     |
-| POST   | `/api/episodes/{ep}/atoms`            | Write atoms (event timestamps are snapped to exact frame timestamps) |
-| GET    | `/api/episodes/{ep}/frame_timestamps` | Frame timestamps for client-side snapping                            |
-| POST   | `/api/export`                         | Rewrite parquet shards into a new directory                          |
-| POST   | `/api/push_to_hub`                    | Export and push to a target repo                                     |
+| Method | Path                                  | Purpose                                                                                               |
+| ------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| GET    | `/api/health`                         | Liveness + style catalog                                                                              |
+| POST   | `/api/dataset/load`                   | Cache + read a dataset's `meta/`                                                                      |
+| GET    | `/api/episodes/{ep}/atoms`            | Read saved atoms                                                                                      |
+| POST   | `/api/episodes/{ep}/atoms`            | Write atoms (event timestamps are snapped to exact frame timestamps)                                  |
+| GET    | `/api/episodes/{ep}/frame_timestamps` | Frame timestamps for client-side snapping                                                             |
+| GET    | `/api/video/transcode`                | Serve a browser-decodable copy of a video (transcodes + caches non-`yuv420p` sources like `gray12le`) |
+| POST   | `/api/export`                         | Rewrite parquet shards into a new directory                                                           |
+| POST   | `/api/push_to_hub`                    | Export and push to a target repo                                                                      |
+
+### Video transcoding
+
+Browsers can only decode 8-bit 4:2:0 (`yuv420p`) via the `<video>` element, so
+depth/IR cameras stored as `gray12le`/`gray16le` (or other exotic pixel
+formats) won't play. The frontend streams videos directly from Hugging Face and
+calls `/api/video/transcode` in two cases: **proactively** for likely-depth
+cameras (key contains `depth`) — since some browsers decode those natively as
+flat grayscale, an error would never fire — and as a **fallback** for any other
+camera whose `<video>` element fails to decode (e.g. AV1 in Safari). The
+endpoint probes the source codec + pixel format with PyAV, serves it untouched
+only if it's already H.264 + yuv420p, otherwise transcodes once to
+`yuv420p` H.264 (in-process, via PyAV) and caches the result on disk (keyed by
+source path + size + mtime + pixel format). Subsequent loads and seeks hit the
+cached file with full HTTP Range support, so playback is as fast as any normal
+video after the one-time conversion. Grayscale depth/IR formats are colorized
+with the **viridis** colormap (via FFmpeg's `pseudocolor` filter) for
+readability, using a fixed, temporally stable range mapping rather than
+per-frame normalization (which would flicker). Override the colormap with the
+`LEROBOT_DEPTH_COLORMAP` env var (any `pseudocolor` preset: `magma`, `inferno`,
+`plasma`, `viridis`, `turbo`, `cividis`, ...).
+
+The colormap range is derived from the depth **quantization parameters** in
+`meta/info.json` (`video.depth_min`, `video.depth_max`, `video.shift`,
+`video.use_log` — lerobot's per-key depth encoding, lerobot#3253). The video
+codes are a shifted-log quantization of physical depth over `[depth_min,
+depth_max]`, so any chosen depth window is run back through that same encode
+(`_encode_depth_norm`) to land in the encoded code domain the `colorlevels`
+filter operates on. Two modes via `LEROBOT_DEPTH_RANGE`:
+
+- `stats` (default): span percentiles from `meta/stats.json` (which low/high
+  percentile keys is set by `LEROBOT_DEPTH_PCTL`, default `q10,q90`; use
+  `q01,q99` for a wider window). Those stats are computed on the **raw uint16
+  depth in millimetres** (a different domain from the log-quantized video
+  pixels), so they're converted to metres and re-encoded before being used as
+  the stretch window — this spreads the colormap across the depth values that
+  actually occur (high contrast) while keeping pixel values meaningful. (Earlier
+  versions normalized the raw-mm percentiles by `2**bits - 1` directly, which
+  mixed the raw and encoded domains.)
+- `fixed`: span the full `[depth_min, depth_max]` range. That encodes to the
+  full code range, so colors are **consistent across episodes/datasets** but
+  lower-contrast; no stretch is applied.
+
+If the encoding metadata is unavailable, it falls back to a full-range colormap.
 
 ## Storage layout
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,11 +24,9 @@ uvicorn app:app --port 7861 --reload
 
 ### Video transcoding dependency (optional)
 
-The video transcode endpoint (`/api/video/transcode`) uses
-[PyAV](https://pyav.org) (in-process FFmpeg bindings) — installed via
-`requirements.txt` as `av`. PyAV's wheels bundle FFmpeg, so there's no separate
-system install. If `av` is not installed, the endpoint returns HTTP 503 and the
-rest of the backend works normally.
+`/api/video/transcode` needs [PyAV](https://pyav.org) (`av` in
+`requirements.txt`; its wheels bundle FFmpeg). Without it the endpoint returns
+503 and the rest of the backend is unaffected.
 
 Then start the Next.js visualizer with the backend URL configured:
 
@@ -38,60 +36,38 @@ NEXT_PUBLIC_ANNOTATE_BACKEND_URL=http://127.0.0.1:7861 bun run dev
 
 ## API
 
-| Method | Path                                  | Purpose                                                                                               |
-| ------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| GET    | `/api/health`                         | Liveness + style catalog                                                                              |
-| POST   | `/api/dataset/load`                   | Cache + read a dataset's `meta/`                                                                      |
-| GET    | `/api/episodes/{ep}/atoms`            | Read saved atoms                                                                                      |
-| POST   | `/api/episodes/{ep}/atoms`            | Write atoms (event timestamps are snapped to exact frame timestamps)                                  |
-| GET    | `/api/episodes/{ep}/frame_timestamps` | Frame timestamps for client-side snapping                                                             |
-| GET    | `/api/video/transcode`                | Serve a browser-decodable copy of a video (transcodes + caches non-`yuv420p` sources like `gray12le`) |
-| POST   | `/api/export`                         | Rewrite parquet shards into a new directory                                                           |
-| POST   | `/api/push_to_hub`                    | Export and push to a target repo                                                                      |
+| Method | Path                                  | Purpose                                                                                                 |
+| ------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/health`                         | Liveness + style catalog                                                                                |
+| POST   | `/api/dataset/load`                   | Cache + read a dataset's `meta/`                                                                        |
+| GET    | `/api/episodes/{ep}/atoms`            | Read saved atoms                                                                                        |
+| POST   | `/api/episodes/{ep}/atoms`            | Write atoms (event timestamps are snapped to exact frame timestamps)                                    |
+| GET    | `/api/episodes/{ep}/frame_timestamps` | Frame timestamps for client-side snapping                                                               |
+| GET    | `/api/video/transcode`                | Serve a browser-decodable copy of a video (transcodes + caches grayscale depth sources like `gray12le`) |
+| POST   | `/api/export`                         | Rewrite parquet shards into a new directory                                                             |
+| POST   | `/api/push_to_hub`                    | Export and push to a target repo                                                                        |
 
 ### Video transcoding
 
-Browsers can only decode 8-bit 4:2:0 (`yuv420p`) via the `<video>` element, so
-depth/IR cameras stored as `gray12le`/`gray16le` (or other exotic pixel
-formats) won't play. The frontend streams videos directly from Hugging Face and
-calls `/api/video/transcode` in two cases: **proactively** for likely-depth
-cameras (key contains `depth`) — since some browsers decode those natively as
-flat grayscale, an error would never fire — and as a **fallback** for any other
-camera whose `<video>` element fails to decode (e.g. AV1 in Safari). The
-endpoint probes the source codec + pixel format with PyAV, serves it untouched
-only if it's already H.264 + yuv420p, otherwise transcodes once to
-`yuv420p` H.264 (in-process, via PyAV) and caches the result on disk (keyed by
-source path + size + mtime + pixel format). Subsequent loads and seeks hit the
-cached file with full HTTP Range support, so playback is as fast as any normal
-video after the one-time conversion. Grayscale depth/IR formats are colorized
-with the **viridis** colormap (via FFmpeg's `pseudocolor` filter) for
-readability, using a fixed, temporally stable range mapping rather than
-per-frame normalization (which would flicker). Override the colormap with the
-`LEROBOT_DEPTH_COLORMAP` env var (any `pseudocolor` preset: `magma`, `inferno`,
-`plasma`, `viridis`, `turbo`, `cividis`, ...).
+Browsers can't decode grayscale depth/IR sources (`gray12le`/`gray16le`). The
+frontend calls `/api/video/transcode` for likely-depth cameras (key contains
+`depth`) proactively — they'd otherwise decode as flat grayscale without
+erroring — and as a fallback when any `<video>` fails to decode. Only grayscale
+sources are transcoded: once to `yuv420p` H.264 with the **viridis** colormap
+(FFmpeg `pseudocolor`), cached on disk keyed by source identity and served with
+HTTP Range support. Everything else is served untouched. Override the colormap
+with `LEROBOT_DEPTH_COLORMAP` (any `pseudocolor` preset).
 
-The colormap range is derived from the depth **quantization parameters** in
-`meta/info.json` (`video.depth_min`, `video.depth_max`, `video.shift`,
-`video.use_log` — lerobot's per-key depth encoding, lerobot#3253). The video
-codes are a shifted-log quantization of physical depth over `[depth_min,
-depth_max]`, so any chosen depth window is run back through that same encode
-(`_encode_depth_norm`) to land in the encoded code domain the `colorlevels`
-filter operates on. Two modes via `LEROBOT_DEPTH_RANGE`:
+The colormap range comes from the depth quantization params in `meta/info.json`
+(`video.depth_min/max/shift/use_log`, lerobot#3253), selected by
+`LEROBOT_DEPTH_RANGE`:
 
-- `stats` (default): span percentiles from `meta/stats.json` (which low/high
-  percentile keys is set by `LEROBOT_DEPTH_PCTL`, default `q10,q90`; use
-  `q01,q99` for a wider window). Those stats are computed on the **raw uint16
-  depth in millimetres** (a different domain from the log-quantized video
-  pixels), so they're converted to metres and re-encoded before being used as
-  the stretch window — this spreads the colormap across the depth values that
-  actually occur (high contrast) while keeping pixel values meaningful. (Earlier
-  versions normalized the raw-mm percentiles by `2**bits - 1` directly, which
-  mixed the raw and encoded domains.)
-- `fixed`: span the full `[depth_min, depth_max]` range. That encodes to the
-  full code range, so colors are **consistent across episodes/datasets** but
-  lower-contrast; no stretch is applied.
+- `stats` (default): span percentiles from `meta/stats.json`
+  (`LEROBOT_DEPTH_PCTL`, default `q10,q90`) for high contrast.
+- `fixed`: span the full depth range — consistent across datasets, lower
+  contrast.
 
-If the encoding metadata is unavailable, it falls back to a full-range colormap.
+Falls back to a full-range colormap when the metadata is missing.
 
 ## Storage layout
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,6 +69,11 @@ The colormap range comes from the depth quantization params in `meta/info.json`
 
 Falls back to a full-range colormap when the metadata is missing.
 
+Downloaded shards (`CACHE_ROOT`) and their transcoded copies (`TRANSCODE_CACHE`)
+are capped on disk: after a new file is added the oldest are evicted (LRU) back
+under the cap. Defaults are `LEROBOT_DATASET_CACHE_MAX_GB=20` and
+`LEROBOT_TRANSCODE_CACHE_MAX_GB=10`; set either to `0` to disable eviction.
+
 ## Storage layout
 
 Annotations are persisted to `<dataset_root>/meta/lerobot_annotations.json`,

--- a/backend/app.py
+++ b/backend/app.py
@@ -57,9 +57,8 @@ logging.basicConfig(level=logging.INFO)
 
 CACHE_ROOT = Path(os.environ.get("LEROBOT_ANNOTATE_CACHE", "/tmp/lerobot_visualizer_annotate_cache"))
 EXPORT_ROOT = Path(os.environ.get("LEROBOT_ANNOTATE_EXPORT", "/tmp/lerobot_visualizer_annotate_exports"))
-# Where transcoded, browser-friendly copies of otherwise-undecodable videos
-# (e.g. depth cameras stored as gray12le/gray16le) are cached. Keyed by the
-# source file's identity so a given shard is only ever transcoded once.
+# Cache for transcoded copies of undecodable videos (e.g. gray12le depth),
+# keyed by source identity so each shard transcodes once.
 TRANSCODE_CACHE = Path(
     os.environ.get("LEROBOT_TRANSCODE_CACHE", "/tmp/lerobot_visualizer_transcode_cache")
 )
@@ -719,81 +718,39 @@ def _do_export(state: DatasetState, output_dir: str | None, copy_videos: bool) -
 
 # --- Video transcoding --------------------------------------------------------
 #
-# Browsers decode the dataset videos natively via the <video> element, which
-# only handles 8-bit 4:2:0 (yuv420p). Depth/IR cameras are frequently stored
-# as gray12le / gray16le (12- or 16-bit single-channel) or other exotic pixel
-# formats that no browser can decode. The frontend streams videos directly
-# from Hugging Face and only calls this endpoint as a *fallback* when a
-# <video> element fails to decode — so the common case never touches PyAV.
-#
-# Transcoding uses PyAV (in-process FFmpeg bindings) rather than shelling out
-# to an ffmpeg binary: no subprocess, no separate system dependency (PyAV's
-# wheels bundle FFmpeg), and frame-level control over the pixel-format
-# conversion.
-#
-# Strategy (efficient by construction):
-#   1. Probe the source pixel format (cheap, container header only).
-#   2. Only grayscale depth/IR sources (e.g. gray12le/gray16le) are
-#      transcoded — no browser can decode them and they need the colormap.
-#      Every other source (incl. AV1/HEVC RGB) is served untouched for the
-#      <video> element to decode natively, so the common case never re-encodes.
-#   3. The transcode runs ONCE to yuv420p H.264 with a viridis colormap,
-#      cached on disk keyed by the source's identity (path + size + mtime +
-#      pix_fmt), and served from cache. Range requests (seeking) are handled
-#      by Starlette's FileResponse against the complete cached file, so
-#      playback is as fast as a normal video after the one-time conversion.
+# Browsers can't decode grayscale depth/IR sources (e.g. gray12le/gray16le).
+# The frontend calls this endpoint as a fallback; only grayscale sources are
+# transcoded — to yuv420p H.264 with a colormap, via in-process PyAV (no ffmpeg
+# subprocess) — then cached on disk keyed by source identity and served with
+# Range support. Every other source is served untouched.
 
-# Grayscale sources (depth/IR cameras, e.g. gray12le) are colorized through
-# this FFmpeg `pseudocolor` preset instead of being shown as flat grayscale —
-# perceptually-uniform colormaps make depth gradients far easier to read.
-# Any preset supported by the `pseudocolor` filter works (magma, inferno,
-# plasma, viridis, turbo, cividis, ...). Override with LEROBOT_DEPTH_COLORMAP.
+# pseudocolor preset used to colorize grayscale depth/IR sources. Any preset the
+# filter supports works (magma, inferno, plasma, viridis, turbo, cividis, ...).
 DEPTH_COLORMAP = os.environ.get("LEROBOT_DEPTH_COLORMAP", "viridis")
 
-# How the colormap range (the depth values mapped across the colormap) is
-# chosen for depth sources:
-#   "stats" — span the configured percentiles (default q10/q90) from
-#             meta/stats.json (default mode). Those are computed on the RAW
-#             uint16 depth (millimetres), so they are converted to metres and
-#             run back through the *same* shifted-log encode
-#             (`_encode_depth_norm`) to land in the encoded code domain before
-#             being used as a `colorlevels` stretch. This spreads the colormap
-#             across the depth values that actually occur (high contrast).
-#   "fixed" — span the full encoded depth range [depth_min, depth_max] taken
-#             from meta/info.json. The codes already are lerobot's shifted-log
-#             normalization over exactly that range, so colors are consistent
-#             across episodes/datasets but lower-contrast.
+# Colormap range source: "stats" spans meta/stats.json percentiles (high
+# contrast); "fixed" spans the full encoded depth range from meta/info.json
+# (consistent across datasets, lower contrast).
 DEPTH_RANGE_MODE = os.environ.get("LEROBOT_DEPTH_RANGE", "stats").lower()
 
-# Which low/high percentile keys from meta/stats.json drive the "stats" window.
-# Tighter percentiles (e.g. q10,q90) clip more aggressively for higher contrast;
-# wider ones (q01,q99) keep more of the range. Override with LEROBOT_DEPTH_PCTL,
-# e.g. "q01,q99".
+# Percentile keys driving the "stats" window (tighter = higher contrast).
 _pctl = os.environ.get("LEROBOT_DEPTH_PCTL", "q10,q90").split(",")
 DEPTH_PCTL_LOW = _pctl[0].strip() or "q10"
 DEPTH_PCTL_HIGH = (_pctl[1].strip() if len(_pctl) > 1 else "q90") or "q90"
 
-# Identifies the current transcode recipe (codec params + colormap). It is
-# mixed into the cache key so that changing the recipe — e.g. switching the
-# depth range derivation — invalidates previously cached outputs instead of
-# serving a stale file produced by the old logic. Bump the version prefix on
-# any recipe change.
+# Mixed into the cache key so a recipe change invalidates stale cached outputs.
 TRANSCODE_RECIPE = (
     f"v3-h264-crf20-gray:{DEPTH_COLORMAP}:{DEPTH_RANGE_MODE}"
     f":{DEPTH_PCTL_LOW}-{DEPTH_PCTL_HIGH}"
 )
 
-# One lock per cache key so concurrent requests for the same shard wait for a
-# single transcode instead of racing (which would corrupt the output file).
+# One lock per cache key so concurrent requests for a shard don't race.
 _transcode_locks: dict[str, threading.Lock] = {}
 _transcode_locks_guard = threading.Lock()
 
 
 def _require_av():
-    """Import PyAV lazily so the rest of the backend works without it.
-
-    Only the transcode endpoint needs PyAV; annotation/export paths don't.
-    """
+    """Import PyAV lazily — only the transcode endpoint needs it."""
     try:
         import av
 
@@ -856,9 +813,7 @@ def _resolve_video_source(
     raise HTTPException(status_code=400, detail="need repo_id or local_path")
 
 
-# Cache of parsed meta/*.json keyed by (filename, dataset), so deriving the
-# colormap window doesn't re-read (and re-HEAD, for HF datasets) on every
-# cache-hit request.
+# Cache of parsed meta/*.json so cache-hit requests don't re-read/re-HEAD.
 _meta_cache: dict[tuple[str, str], dict[str, Any] | None] = {}
 _meta_cache_guard = threading.Lock()
 
@@ -918,13 +873,10 @@ def _load_meta_json(
 def _depth_feature_params(
     info: dict[str, Any] | None, rel_path: str
 ) -> dict[str, Any] | None:
-    """Extract the depth encoding parameters for the feature in ``rel_path``.
+    """Depth encoding params (lerobot#3253) for the feature in ``rel_path``, or None.
 
-    Reads the lerobot per-video-key encoding metadata (added in lerobot#3253)
-    from ``meta/info.json``: ``video.depth_min`` / ``video.depth_max`` (the
-    physical range in metres), ``video.shift`` and ``video.use_log`` (the
-    shifted-log quantization). Returns None unless the matching feature carries
-    a depth range.
+    Reads video.depth_min/depth_max (metres) and video.shift/use_log from
+    meta/info.json.
     """
     features = (info or {}).get("features")
     if not isinstance(features, dict):
@@ -933,8 +885,7 @@ def _depth_feature_params(
     if not key:
         return None
     feature = features.get(key) or {}
-    # Encoding params live under "info" (per the lerobot feature schema), but
-    # tolerate them sitting directly on the feature too.
+    # Params live under "info", but tolerate them directly on the feature too.
     finfo = feature.get("info") if isinstance(feature.get("info"), dict) else feature
     dmin = _stat_scalar(finfo.get("video.depth_min"))
     dmax = _stat_scalar(finfo.get("video.depth_max"))
@@ -951,16 +902,11 @@ def _depth_feature_params(
 def _encode_depth_norm(depth_m: float, params: dict[str, Any]) -> float | None:
     """Map a physical depth (metres) to lerobot's encoded code, normalized 0..1.
 
-    Mirrors the shifted-log quantization used when the depth video was written
-    (lerobot#3253), so a depth value can be placed in the encoded pixel domain
-    that the colormap actually operates on::
+    Mirrors the shifted-log quantization (lerobot#3253) so a depth value lands in
+    the encoded domain the colormap operates on; linear when use_log is False::
 
         norm = (ln(d + shift) - ln(dmin + shift))
                / (ln(dmax + shift) - ln(dmin + shift))
-
-    Falls back to a plain linear normalization when ``use_log`` is False. The
-    input is clamped to ``[depth_min, depth_max]`` first. Returns None when the
-    range is degenerate.
     """
     dmin = params.get("depth_min")
     dmax = params.get("depth_max")
@@ -979,12 +925,7 @@ def _encode_depth_norm(depth_m: float, params: dict[str, Any]) -> float | None:
 
 
 def _match_feature_key(stats: dict[str, Any], rel_path: str) -> str | None:
-    """Find the stats feature key contained in the video path (longest match).
-
-    e.g. ``videos/observation.images.top_depth/chunk-000/file-000.mp4`` matches
-    ``observation.images.top_depth`` (preferred over the shorter, also-present
-    ``observation.images.top``).
-    """
+    """Stats feature key contained in the video path, preferring the longest match."""
     candidates = [k for k in stats if k and k in rel_path]
     return max(candidates, key=len) if candidates else None
 
@@ -996,27 +937,12 @@ def _depth_colormap_window(
     rel_path: str,
     hf_token: str | None,
 ) -> tuple[float, float] | None:
-    """Derive a [low, high] colormap window (0..1, encoded domain) for depth.
+    """[low, high] colormap stretch window (0..1, encoded domain) for depth.
 
-    The colormap operates on the encoded video codes, which are lerobot's
-    shifted-log quantization of the physical depth over ``[depth_min,
-    depth_max]`` (read from ``meta/info.json``). The chosen depth range is
-    therefore put *through that same encode* (``_encode_depth_norm``) so it
-    lands in the code domain the `colorlevels` filter expects.
-
-    Two modes (``LEROBOT_DEPTH_RANGE``):
-
-    - ``stats`` (default): span the configured percentiles (``DEPTH_PCTL_LOW``/
-      ``DEPTH_PCTL_HIGH``, default q10/q90) from ``meta/stats.json``. Those are
-      computed on the RAW uint16 depth in millimetres, so they are converted to
-      metres and re-encoded into the code domain before being used as a stretch
-      window (higher contrast, data-dependent).
-    - ``fixed``: span the full ``[depth_min, depth_max]`` range. By construction
-      that encodes to the full ``[0, 1]`` code range, so no stretch is needed
-      and we return None (colors stay consistent across episodes).
-
-    Returns None (full-range colormap, no stretch) when metadata is missing or
-    the window would be degenerate.
+    In "stats" mode, percentiles from meta/stats.json (raw uint16 mm) are
+    converted to metres and run through ``_encode_depth_norm`` into the code
+    domain the colorlevels filter expects. Returns None (no stretch) in "fixed"
+    mode or when metadata is missing/degenerate.
     """
     if DEPTH_RANGE_MODE != "stats":
         # Fixed mode: [depth_min, depth_max] == full encoded range, no stretch.
@@ -1072,13 +998,8 @@ def _probe_video(src: Path) -> tuple[str | None, str | None]:
 
 
 def _needs_transcode(pix_fmt: str | None) -> bool:
-    """Whether ``src`` must be transcoded for the browser's <video> element.
-
-    Only grayscale depth/IR sources (e.g. gray12le, gray16le) qualify: no
-    browser can decode them, and they need the colormap to be readable. Every
-    other source — including AV1/HEVC RGB — is left for the <video> element to
-    decode natively (with the frontend's onError path as a last-resort fallback).
-    """
+    """True only for grayscale depth/IR sources (e.g. gray12le); everything else
+    is left for the browser to decode natively."""
     return (pix_fmt or "").startswith("gray")
 
 
@@ -1101,22 +1022,13 @@ def _transcode_cache_path(
 
 
 def _build_depth_colormap_graph(av, in_stream, window: tuple[float, float] | None):
-    """Filter graph that colorizes a grayscale (depth) stream with a colormap.
+    """Colorize a grayscale depth stream: gbrp -> [colorlevels] -> pseudocolor
+    -> yuv420p.
 
-    Chain: format=gbrp -> [colorlevels stretch] -> pseudocolor=preset=<map>
-           -> format=yuv420p.
-
-    The `gbrp` step is required because `pseudocolor` preserves the input
-    pixel format — a gray input would only ever yield gray output, so we first
-    promote to a packed-colour planar format that the filter can write the
-    colormap into. Converting from a high-bit-depth gray source to gbrp also
-    rescales the luma range into 0..255 with a fixed (temporally stable)
-    mapping, so depth gradients don't flicker frame to frame.
-
-    When ``window`` (a [low, high] pair in 0..1, in the encoded depth domain —
-    see ``_depth_colormap_window``) is given, a `colorlevels` filter first
-    stretches that input range to full scale, so the colormap spans the depth
-    values that actually occur rather than the whole sensor range.
+    gbrp is required because pseudocolor preserves the input format (gray in =>
+    gray out) and it gives a fixed luma->0..255 mapping so gradients don't
+    flicker. ``window`` (see ``_depth_colormap_window``) stretches the colormap
+    over the depth range that actually occurs.
     """
     chain: list[tuple[str, str]] = [("format", "gbrp")]
     if window is not None:
@@ -1148,12 +1060,8 @@ def _transcode_to_web(
     dst: Path,
     window: tuple[float, float] | None = None,
 ) -> None:
-    """Transcode a grayscale depth/IR source to a browser-friendly file.
-
-    The source (gray, gray10le, gray12le, gray16le) is colorized with the
-    ``DEPTH_COLORMAP`` colormap (viridis by default) and written as yuv420p
-    H.264 at ``dst`` — stretched to ``window`` when one is given.
-    """
+    """Colorize a grayscale depth source and write it as yuv420p H.264 at ``dst``,
+    stretched to ``window`` when given."""
     av = _require_av()
     TRANSCODE_CACHE.mkdir(parents=True, exist_ok=True)
     tmp = dst.with_suffix(".partial.mp4")
@@ -1236,9 +1144,6 @@ def _ensure_web_playable(
     if not _needs_transcode(pix_fmt):
         return src
 
-    # Grayscale (depth/IR) sources are colorized; the colormap spans the depth
-    # range derived from meta/info.json encoding params (optionally stretched to
-    # observed stats — see _depth_colormap_window).
     window = _depth_colormap_window(repo_id, revision, local_path, rel_path, hf_token)
 
     dst = _transcode_cache_path(src, codec, pix_fmt, window)
@@ -1295,10 +1200,8 @@ def transcode_video(
 ) -> FileResponse:
     """Serve a browser-decodable copy of a dataset video.
 
-    The frontend calls this only when a <video> element fails to decode the
-    original (e.g. depth cameras stored as gray12le). Web-playable sources are
-    streamed back untouched; everything else is transcoded once and cached.
-    Starlette's FileResponse handles HTTP Range, so seeking works normally.
+    Grayscale depth sources are transcoded once and cached; everything else is
+    streamed back untouched. FileResponse handles HTTP Range for seeking.
     """
     src = _resolve_video_source(repo_id, revision, local_path, path, hf_token)
     served = _ensure_web_playable(

--- a/backend/app.py
+++ b/backend/app.py
@@ -63,6 +63,81 @@ TRANSCODE_CACHE = Path(
     os.environ.get("LEROBOT_TRANSCODE_CACHE", "/tmp/lerobot_visualizer_transcode_cache")
 )
 
+
+def _env_gb_to_bytes(name: str, default_gb: float) -> int:
+    try:
+        gb = float(os.environ.get(name, default_gb))
+    except ValueError:
+        gb = default_gb
+    return int(gb * 1024**3)
+
+
+# Soft disk caps. After a new file is cached/downloaded the oldest files are
+# evicted until the directory is back under its cap (LRU by mtime). The big
+# consumers are downloaded video shards (CACHE_ROOT) and their transcoded copies
+# (TRANSCODE_CACHE); both grow without bound across datasets otherwise. Set the
+# env vars to 0 to disable eviction.
+TRANSCODE_CACHE_MAX_BYTES = _env_gb_to_bytes("LEROBOT_TRANSCODE_CACHE_MAX_GB", 10)
+DATASET_CACHE_MAX_BYTES = _env_gb_to_bytes("LEROBOT_DATASET_CACHE_MAX_GB", 20)
+_prune_guard = threading.Lock()
+
+
+def _prune_cache_dir(
+    root: Path,
+    max_bytes: int,
+    *,
+    keep: Path | None = None,
+    skip_parts: tuple[str, ...] = (),
+    skip_suffixes: tuple[str, ...] = (),
+) -> None:
+    """Evict the oldest files under ``root`` until its size is <= ``max_bytes``.
+
+    LRU by mtime (callers bump it with ``os.utime`` on cache hits). ``keep`` is
+    never evicted; files whose path contains a ``skip_parts`` segment (e.g.
+    ``meta``) or whose name ends with a ``skip_suffixes`` value (e.g. a partial
+    write) are ignored entirely. Best-effort: missing files / races are skipped.
+    """
+    if max_bytes <= 0 or not root.exists():
+        return
+    with _prune_guard:
+        entries: list[tuple[float, int, Path]] = []
+        total = 0
+        for path in root.rglob("*"):
+            if path.is_symlink() or not path.is_file():
+                continue
+            if skip_parts and any(part in skip_parts for part in path.parts):
+                continue
+            if skip_suffixes and path.name.endswith(skip_suffixes):
+                continue
+            try:
+                st = path.stat()
+            except OSError:
+                continue
+            entries.append((st.st_mtime, st.st_size, path))
+            total += st.st_size
+        if total <= max_bytes:
+            return
+
+        keep_resolved = keep.resolve() if keep else None
+        freed = 0
+        for _mtime, size, path in sorted(entries):  # oldest first
+            if total - freed <= max_bytes:
+                break
+            if keep_resolved and path.resolve() == keep_resolved:
+                continue
+            try:
+                path.unlink()
+                freed += size
+            except OSError:
+                continue
+        if freed:
+            logger.info(
+                "pruned %.1f MB from %s (cap %.1f GB)",
+                freed / 1024**2,
+                root,
+                max_bytes / 1024**3,
+            )
+
 # --- Schema mirrors src/lerobot/datasets/language.py --------------------------
 
 PERSISTENT_STYLES = {"task_aug", "subtask", "plan", "memory"}
@@ -730,7 +805,7 @@ DEPTH_COLORMAP = os.environ.get("LEROBOT_DEPTH_COLORMAP", "viridis")
 
 # Colormap range source: "stats" spans meta/stats.json percentiles (high
 # contrast); "fixed" spans the full encoded depth range from meta/info.json
-# (consistent across datasets, lower contrast).
+# (consistent across cameras/datasets, lower contrast).
 DEPTH_RANGE_MODE = os.environ.get("LEROBOT_DEPTH_RANGE", "stats").lower()
 
 # Percentile keys driving the "stats" window (tighter = higher contrast).
@@ -797,6 +872,7 @@ def _resolve_video_source(
         slug = repo_id.replace("/", "__") + (f"@{revision}" if revision else "")
         root = CACHE_ROOT / slug
         root.mkdir(parents=True, exist_ok=True)
+        existed = (root / rel).exists()
         try:
             downloaded = hf_hub_download(
                 repo_id=repo_id,
@@ -808,7 +884,21 @@ def _resolve_video_source(
             )
         except Exception as e:  # noqa: BLE001
             raise HTTPException(status_code=404, detail=f"could not fetch video: {e}")
-        return Path(downloaded)
+        path = Path(downloaded)
+        try:
+            os.utime(path, None)  # LRU: mark recently used
+        except OSError:
+            pass
+        # Only prune when we actually added a file; skip meta/ (needed by loaded
+        # datasets) and hf_hub's internal .cache bookkeeping.
+        if not existed:
+            _prune_cache_dir(
+                CACHE_ROOT,
+                DATASET_CACHE_MAX_BYTES,
+                keep=path,
+                skip_parts=("meta", ".cache"),
+            )
+        return path
 
     raise HTTPException(status_code=400, detail="need repo_id or local_path")
 
@@ -1147,23 +1237,30 @@ def _ensure_web_playable(
     window = _depth_colormap_window(repo_id, revision, local_path, rel_path, hf_token)
 
     dst = _transcode_cache_path(src, codec, pix_fmt, window)
-    if dst.exists() and dst.stat().st_size > 0:
-        return dst
-
-    with _lock_for(dst.name):
-        # Re-check inside the lock: a concurrent request may have finished
-        # the transcode while we were waiting.
-        if dst.exists() and dst.stat().st_size > 0:
-            return dst
-        logger.info(
-            "transcoding %s (codec=%s pix_fmt=%s window=%s) -> %s",
-            src,
-            codec,
-            pix_fmt,
-            window,
-            dst.name,
-        )
-        _transcode_to_web(src, dst, window)
+    if not (dst.exists() and dst.stat().st_size > 0):
+        with _lock_for(dst.name):
+            # Re-check inside the lock: a concurrent request may have finished
+            # the transcode while we were waiting.
+            if not (dst.exists() and dst.stat().st_size > 0):
+                logger.info(
+                    "transcoding %s (codec=%s pix_fmt=%s window=%s) -> %s",
+                    src,
+                    codec,
+                    pix_fmt,
+                    window,
+                    dst.name,
+                )
+                _transcode_to_web(src, dst, window)
+                _prune_cache_dir(
+                    TRANSCODE_CACHE,
+                    TRANSCODE_CACHE_MAX_BYTES,
+                    keep=dst,
+                    skip_suffixes=(".partial.mp4",),
+                )
+    try:
+        os.utime(dst, None)  # LRU: mark recently used
+    except OSError:
+        pass
     return dst
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,11 +31,15 @@ Then in another terminal:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import math
 import os
 import shutil
+import threading
 from dataclasses import dataclass, field
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +48,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from pydantic import BaseModel
 
@@ -53,6 +57,12 @@ logging.basicConfig(level=logging.INFO)
 
 CACHE_ROOT = Path(os.environ.get("LEROBOT_ANNOTATE_CACHE", "/tmp/lerobot_visualizer_annotate_cache"))
 EXPORT_ROOT = Path(os.environ.get("LEROBOT_ANNOTATE_EXPORT", "/tmp/lerobot_visualizer_annotate_exports"))
+# Where transcoded, browser-friendly copies of otherwise-undecodable videos
+# (e.g. depth cameras stored as gray12le/gray16le) are cached. Keyed by the
+# source file's identity so a given shard is only ever transcoded once.
+TRANSCODE_CACHE = Path(
+    os.environ.get("LEROBOT_TRANSCODE_CACHE", "/tmp/lerobot_visualizer_transcode_cache")
+)
 
 # --- Schema mirrors src/lerobot/datasets/language.py --------------------------
 
@@ -707,6 +717,551 @@ def _do_export(state: DatasetState, output_dir: str | None, copy_videos: bool) -
     return {"output_dir": str(out_root), "persistent_rows": n_persistent, "event_rows": n_events}
 
 
+# --- Video transcoding --------------------------------------------------------
+#
+# Browsers decode the dataset videos natively via the <video> element, which
+# only handles 8-bit 4:2:0 (yuv420p). Depth/IR cameras are frequently stored
+# as gray12le / gray16le (12- or 16-bit single-channel) or other exotic pixel
+# formats that no browser can decode. The frontend streams videos directly
+# from Hugging Face and only calls this endpoint as a *fallback* when a
+# <video> element fails to decode — so the common case never touches PyAV.
+#
+# Transcoding uses PyAV (in-process FFmpeg bindings) rather than shelling out
+# to an ffmpeg binary: no subprocess, no separate system dependency (PyAV's
+# wheels bundle FFmpeg), and frame-level control over the pixel-format
+# conversion.
+#
+# Strategy (efficient by construction):
+#   1. Probe the source pixel format (cheap, container header only).
+#   2. Only grayscale depth/IR sources (e.g. gray12le/gray16le) are
+#      transcoded — no browser can decode them and they need the colormap.
+#      Every other source (incl. AV1/HEVC RGB) is served untouched for the
+#      <video> element to decode natively, so the common case never re-encodes.
+#   3. The transcode runs ONCE to yuv420p H.264 with a viridis colormap,
+#      cached on disk keyed by the source's identity (path + size + mtime +
+#      pix_fmt), and served from cache. Range requests (seeking) are handled
+#      by Starlette's FileResponse against the complete cached file, so
+#      playback is as fast as a normal video after the one-time conversion.
+
+# Grayscale sources (depth/IR cameras, e.g. gray12le) are colorized through
+# this FFmpeg `pseudocolor` preset instead of being shown as flat grayscale —
+# perceptually-uniform colormaps make depth gradients far easier to read.
+# Any preset supported by the `pseudocolor` filter works (magma, inferno,
+# plasma, viridis, turbo, cividis, ...). Override with LEROBOT_DEPTH_COLORMAP.
+DEPTH_COLORMAP = os.environ.get("LEROBOT_DEPTH_COLORMAP", "viridis")
+
+# How the colormap range (the depth values mapped across the colormap) is
+# chosen for depth sources:
+#   "stats" — span the configured percentiles (default q10/q90) from
+#             meta/stats.json (default mode). Those are computed on the RAW
+#             uint16 depth (millimetres), so they are converted to metres and
+#             run back through the *same* shifted-log encode
+#             (`_encode_depth_norm`) to land in the encoded code domain before
+#             being used as a `colorlevels` stretch. This spreads the colormap
+#             across the depth values that actually occur (high contrast).
+#   "fixed" — span the full encoded depth range [depth_min, depth_max] taken
+#             from meta/info.json. The codes already are lerobot's shifted-log
+#             normalization over exactly that range, so colors are consistent
+#             across episodes/datasets but lower-contrast.
+DEPTH_RANGE_MODE = os.environ.get("LEROBOT_DEPTH_RANGE", "stats").lower()
+
+# Which low/high percentile keys from meta/stats.json drive the "stats" window.
+# Tighter percentiles (e.g. q10,q90) clip more aggressively for higher contrast;
+# wider ones (q01,q99) keep more of the range. Override with LEROBOT_DEPTH_PCTL,
+# e.g. "q01,q99".
+_pctl = os.environ.get("LEROBOT_DEPTH_PCTL", "q10,q90").split(",")
+DEPTH_PCTL_LOW = _pctl[0].strip() or "q10"
+DEPTH_PCTL_HIGH = (_pctl[1].strip() if len(_pctl) > 1 else "q90") or "q90"
+
+# Identifies the current transcode recipe (codec params + colormap). It is
+# mixed into the cache key so that changing the recipe — e.g. switching the
+# depth range derivation — invalidates previously cached outputs instead of
+# serving a stale file produced by the old logic. Bump the version prefix on
+# any recipe change.
+TRANSCODE_RECIPE = (
+    f"v3-h264-crf20-gray:{DEPTH_COLORMAP}:{DEPTH_RANGE_MODE}"
+    f":{DEPTH_PCTL_LOW}-{DEPTH_PCTL_HIGH}"
+)
+
+# One lock per cache key so concurrent requests for the same shard wait for a
+# single transcode instead of racing (which would corrupt the output file).
+_transcode_locks: dict[str, threading.Lock] = {}
+_transcode_locks_guard = threading.Lock()
+
+
+def _require_av():
+    """Import PyAV lazily so the rest of the backend works without it.
+
+    Only the transcode endpoint needs PyAV; annotation/export paths don't.
+    """
+    try:
+        import av
+
+        return av
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="PyAV is not installed — run `pip install av` to enable "
+            "video transcoding",
+        )
+
+
+def _lock_for(key: str) -> threading.Lock:
+    with _transcode_locks_guard:
+        lock = _transcode_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _transcode_locks[key] = lock
+        return lock
+
+
+def _resolve_video_source(
+    repo_id: str | None,
+    revision: str | None,
+    local_path: str | None,
+    rel_path: str,
+    hf_token: str | None,
+) -> Path:
+    """Locate (downloading from HF if needed) the source video file."""
+    rel = rel_path.lstrip("/")
+    if not rel or ".." in Path(rel).parts:
+        raise HTTPException(status_code=400, detail="invalid video path")
+
+    if local_path:
+        root = Path(local_path).expanduser().resolve()
+        full = (root / rel).resolve()
+        if not str(full).startswith(str(root)):
+            raise HTTPException(status_code=400, detail="path escapes dataset root")
+        if not full.exists():
+            raise HTTPException(status_code=404, detail=f"video not found: {rel}")
+        return full
+
+    if repo_id:
+        slug = repo_id.replace("/", "__") + (f"@{revision}" if revision else "")
+        root = CACHE_ROOT / slug
+        root.mkdir(parents=True, exist_ok=True)
+        try:
+            downloaded = hf_hub_download(
+                repo_id=repo_id,
+                repo_type="dataset",
+                filename=rel,
+                revision=revision,
+                local_dir=root,
+                token=hf_token or None,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=404, detail=f"could not fetch video: {e}")
+        return Path(downloaded)
+
+    raise HTTPException(status_code=400, detail="need repo_id or local_path")
+
+
+# Cache of parsed meta/*.json keyed by (filename, dataset), so deriving the
+# colormap window doesn't re-read (and re-HEAD, for HF datasets) on every
+# cache-hit request.
+_meta_cache: dict[tuple[str, str], dict[str, Any] | None] = {}
+_meta_cache_guard = threading.Lock()
+
+
+def _stat_scalar(value: Any) -> float | None:
+    """Flatten lerobot's nested per-channel stat (e.g. [[[x]]]) to a scalar."""
+    while isinstance(value, list):
+        if not value:
+            return None
+        value = value[0]
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_meta_json(
+    rel_name: str,
+    repo_id: str | None,
+    revision: str | None,
+    local_path: str | None,
+    hf_token: str | None,
+) -> dict[str, Any] | None:
+    """Load and cache a ``meta/<rel_name>`` JSON file for a dataset (or None)."""
+    dataset = local_path or f"{repo_id}@{revision or 'main'}"
+    cache_key = (rel_name, dataset)
+    with _meta_cache_guard:
+        if cache_key in _meta_cache:
+            return _meta_cache[cache_key]
+
+    data: dict[str, Any] | None = None
+    try:
+        if local_path:
+            p = Path(local_path).expanduser().resolve() / "meta" / rel_name
+            if p.exists():
+                data = json.loads(p.read_text())
+        elif repo_id:
+            slug = repo_id.replace("/", "__") + (f"@{revision}" if revision else "")
+            downloaded = hf_hub_download(
+                repo_id=repo_id,
+                repo_type="dataset",
+                filename=f"meta/{rel_name}",
+                revision=revision,
+                local_dir=CACHE_ROOT / slug,
+                token=hf_token or None,
+            )
+            data = json.loads(Path(downloaded).read_text())
+    except Exception as e:  # noqa: BLE001
+        logger.warning("could not load meta/%s (%s): %s", rel_name, dataset, e)
+        data = None
+
+    with _meta_cache_guard:
+        _meta_cache[cache_key] = data
+    return data
+
+
+def _depth_feature_params(
+    info: dict[str, Any] | None, rel_path: str
+) -> dict[str, Any] | None:
+    """Extract the depth encoding parameters for the feature in ``rel_path``.
+
+    Reads the lerobot per-video-key encoding metadata (added in lerobot#3253)
+    from ``meta/info.json``: ``video.depth_min`` / ``video.depth_max`` (the
+    physical range in metres), ``video.shift`` and ``video.use_log`` (the
+    shifted-log quantization). Returns None unless the matching feature carries
+    a depth range.
+    """
+    features = (info or {}).get("features")
+    if not isinstance(features, dict):
+        return None
+    key = _match_feature_key(features, rel_path)
+    if not key:
+        return None
+    feature = features.get(key) or {}
+    # Encoding params live under "info" (per the lerobot feature schema), but
+    # tolerate them sitting directly on the feature too.
+    finfo = feature.get("info") if isinstance(feature.get("info"), dict) else feature
+    dmin = _stat_scalar(finfo.get("video.depth_min"))
+    dmax = _stat_scalar(finfo.get("video.depth_max"))
+    if dmin is None or dmax is None:
+        return None
+    return {
+        "depth_min": dmin,
+        "depth_max": dmax,
+        "shift": _stat_scalar(finfo.get("video.shift")) or 0.0,
+        "use_log": bool(finfo.get("video.use_log", False)),
+    }
+
+
+def _encode_depth_norm(depth_m: float, params: dict[str, Any]) -> float | None:
+    """Map a physical depth (metres) to lerobot's encoded code, normalized 0..1.
+
+    Mirrors the shifted-log quantization used when the depth video was written
+    (lerobot#3253), so a depth value can be placed in the encoded pixel domain
+    that the colormap actually operates on::
+
+        norm = (ln(d + shift) - ln(dmin + shift))
+               / (ln(dmax + shift) - ln(dmin + shift))
+
+    Falls back to a plain linear normalization when ``use_log`` is False. The
+    input is clamped to ``[depth_min, depth_max]`` first. Returns None when the
+    range is degenerate.
+    """
+    dmin = params.get("depth_min")
+    dmax = params.get("depth_max")
+    if dmin is None or dmax is None or dmax <= dmin:
+        return None
+    shift = params.get("shift") or 0.0
+    d = min(max(depth_m, dmin), dmax)
+    if params.get("use_log"):
+        denom = math.log(dmax + shift) - math.log(dmin + shift)
+        if denom <= 0:
+            return None
+        norm = (math.log(d + shift) - math.log(dmin + shift)) / denom
+    else:
+        norm = (d - dmin) / (dmax - dmin)
+    return min(1.0, max(0.0, norm))
+
+
+def _match_feature_key(stats: dict[str, Any], rel_path: str) -> str | None:
+    """Find the stats feature key contained in the video path (longest match).
+
+    e.g. ``videos/observation.images.top_depth/chunk-000/file-000.mp4`` matches
+    ``observation.images.top_depth`` (preferred over the shorter, also-present
+    ``observation.images.top``).
+    """
+    candidates = [k for k in stats if k and k in rel_path]
+    return max(candidates, key=len) if candidates else None
+
+
+def _depth_colormap_window(
+    repo_id: str | None,
+    revision: str | None,
+    local_path: str | None,
+    rel_path: str,
+    hf_token: str | None,
+) -> tuple[float, float] | None:
+    """Derive a [low, high] colormap window (0..1, encoded domain) for depth.
+
+    The colormap operates on the encoded video codes, which are lerobot's
+    shifted-log quantization of the physical depth over ``[depth_min,
+    depth_max]`` (read from ``meta/info.json``). The chosen depth range is
+    therefore put *through that same encode* (``_encode_depth_norm``) so it
+    lands in the code domain the `colorlevels` filter expects.
+
+    Two modes (``LEROBOT_DEPTH_RANGE``):
+
+    - ``stats`` (default): span the configured percentiles (``DEPTH_PCTL_LOW``/
+      ``DEPTH_PCTL_HIGH``, default q10/q90) from ``meta/stats.json``. Those are
+      computed on the RAW uint16 depth in millimetres, so they are converted to
+      metres and re-encoded into the code domain before being used as a stretch
+      window (higher contrast, data-dependent).
+    - ``fixed``: span the full ``[depth_min, depth_max]`` range. By construction
+      that encodes to the full ``[0, 1]`` code range, so no stretch is needed
+      and we return None (colors stay consistent across episodes).
+
+    Returns None (full-range colormap, no stretch) when metadata is missing or
+    the window would be degenerate.
+    """
+    if DEPTH_RANGE_MODE != "stats":
+        # Fixed mode: [depth_min, depth_max] == full encoded range, no stretch.
+        return None
+
+    info = _load_meta_json("info.json", repo_id, revision, local_path, hf_token)
+    params = _depth_feature_params(info, rel_path)
+    if not params:
+        return None
+
+    stats = _load_meta_json("stats.json", repo_id, revision, local_path, hf_token)
+    if not stats:
+        return None
+    key = _match_feature_key(stats, rel_path)
+    if not key:
+        return None
+    feature = stats[key]
+    lo_mm = _stat_scalar(feature.get(DEPTH_PCTL_LOW))
+    if lo_mm is None:
+        lo_mm = _stat_scalar(feature.get("min"))
+    hi_mm = _stat_scalar(feature.get(DEPTH_PCTL_HIGH))
+    if hi_mm is None:
+        hi_mm = _stat_scalar(feature.get("max"))
+    if lo_mm is None or hi_mm is None:
+        return None
+
+    # Raw depth stats are uint16 millimetres; encode expects metres.
+    low = _encode_depth_norm(lo_mm / 1000.0, params)
+    high = _encode_depth_norm(hi_mm / 1000.0, params)
+    if low is None or high is None or high <= low:
+        return None
+    return (low, high)
+
+
+def _probe_video(src: Path) -> tuple[str | None, str | None]:
+    """Read the first video stream's (codec_name, pixel format) — no decode."""
+    av = _require_av()
+    try:
+        with av.open(str(src)) as container:
+            streams = container.streams.video
+            if not streams:
+                return (None, None)
+            stream = streams[0]
+            codec = getattr(stream.codec_context, "name", None)
+            try:
+                pix_fmt = stream.format.name
+            except Exception:  # noqa: BLE001
+                pix_fmt = getattr(stream.codec_context, "pix_fmt", None)
+            return (codec, pix_fmt)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("video probe failed for %s: %s", src, e)
+        return (None, None)
+
+
+def _needs_transcode(pix_fmt: str | None) -> bool:
+    """Whether ``src`` must be transcoded for the browser's <video> element.
+
+    Only grayscale depth/IR sources (e.g. gray12le, gray16le) qualify: no
+    browser can decode them, and they need the colormap to be readable. Every
+    other source — including AV1/HEVC RGB — is left for the <video> element to
+    decode natively (with the frontend's onError path as a last-resort fallback).
+    """
+    return (pix_fmt or "").startswith("gray")
+
+
+def _transcode_cache_path(
+    src: Path,
+    codec: str | None,
+    pix_fmt: str | None,
+    window: tuple[float, float] | None,
+) -> Path:
+    st = src.stat()
+    h = hashlib.sha256()
+    h.update(str(src.resolve()).encode())
+    h.update(str(st.st_size).encode())
+    h.update(str(st.st_mtime_ns).encode())
+    h.update((codec or "unknown").encode())
+    h.update((pix_fmt or "unknown").encode())
+    h.update(repr(window).encode())
+    h.update(TRANSCODE_RECIPE.encode())
+    return TRANSCODE_CACHE / f"{h.hexdigest()}.mp4"
+
+
+def _build_depth_colormap_graph(av, in_stream, window: tuple[float, float] | None):
+    """Filter graph that colorizes a grayscale (depth) stream with a colormap.
+
+    Chain: format=gbrp -> [colorlevels stretch] -> pseudocolor=preset=<map>
+           -> format=yuv420p.
+
+    The `gbrp` step is required because `pseudocolor` preserves the input
+    pixel format — a gray input would only ever yield gray output, so we first
+    promote to a packed-colour planar format that the filter can write the
+    colormap into. Converting from a high-bit-depth gray source to gbrp also
+    rescales the luma range into 0..255 with a fixed (temporally stable)
+    mapping, so depth gradients don't flicker frame to frame.
+
+    When ``window`` (a [low, high] pair in 0..1, in the encoded depth domain —
+    see ``_depth_colormap_window``) is given, a `colorlevels` filter first
+    stretches that input range to full scale, so the colormap spans the depth
+    values that actually occur rather than the whole sensor range.
+    """
+    chain: list[tuple[str, str]] = [("format", "gbrp")]
+    if window is not None:
+        low, high = window
+        chain.append(
+            (
+                "colorlevels",
+                f"rimin={low:.6f}:rimax={high:.6f}:"
+                f"gimin={low:.6f}:gimax={high:.6f}:"
+                f"bimin={low:.6f}:bimax={high:.6f}",
+            )
+        )
+    chain.append(("pseudocolor", f"preset={DEPTH_COLORMAP}"))
+    chain.append(("format", "yuv420p"))
+
+    graph = av.filter.Graph()
+    last = graph.add_buffer(template=in_stream)
+    for name, args in chain:
+        node = graph.add(name, args)
+        last.link_to(node)
+        last = node
+    last.link_to(graph.add("buffersink"))
+    graph.configure()
+    return graph
+
+
+def _transcode_to_web(
+    src: Path,
+    dst: Path,
+    window: tuple[float, float] | None = None,
+) -> None:
+    """Transcode a grayscale depth/IR source to a browser-friendly file.
+
+    The source (gray, gray10le, gray12le, gray16le) is colorized with the
+    ``DEPTH_COLORMAP`` colormap (viridis by default) and written as yuv420p
+    H.264 at ``dst`` — stretched to ``window`` when one is given.
+    """
+    av = _require_av()
+    TRANSCODE_CACHE.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_suffix(".partial.mp4")
+
+    try:
+        # +faststart moves the moov atom to the front so the browser can begin
+        # playback / seeking without downloading the whole file first.
+        with av.open(str(src)) as in_container, av.open(
+            str(tmp), mode="w", options={"movflags": "+faststart"}
+        ) as out_container:
+            in_streams = in_container.streams.video
+            if not in_streams:
+                raise HTTPException(status_code=400, detail="no video stream")
+            in_stream = in_streams[0]
+            in_stream.thread_type = "AUTO"
+
+            rate = (
+                in_stream.average_rate
+                or in_stream.guessed_rate
+                or Fraction(30, 1)
+            )
+            out_stream = out_container.add_stream("libx264", rate=rate)
+            out_stream.width = in_stream.codec_context.width
+            out_stream.height = in_stream.codec_context.height
+            out_stream.pix_fmt = "yuv420p"
+            out_stream.options = {"crf": "20", "preset": "veryfast"}
+
+            graph = _build_depth_colormap_graph(av, in_stream, window)
+
+            def encode_and_mux(frame) -> None:
+                for packet in out_stream.encode(frame):
+                    out_container.mux(packet)
+
+            def drain_graph() -> None:
+                # Pull every frame the graph can currently produce. EAGAIN
+                # (needs more input) and EOF surface as the builtin
+                # BlockingIOError / EOFError, which PyAV's errors subclass.
+                while True:
+                    try:
+                        encode_and_mux(graph.pull())
+                    except (BlockingIOError, EOFError):
+                        return
+
+            for frame in in_container.decode(in_stream):
+                graph.push(frame)
+                drain_graph()
+
+            graph.push(None)  # flush the filter graph
+            drain_graph()
+            # Flush the encoder.
+            for packet in out_stream.encode():
+                out_container.mux(packet)
+    except HTTPException:
+        tmp.unlink(missing_ok=True)
+        raise
+    except Exception as e:  # noqa: BLE001
+        tmp.unlink(missing_ok=True)
+        logger.error("PyAV transcode failed for %s: %s", src, e)
+        raise HTTPException(status_code=500, detail="video transcode failed")
+
+    if not tmp.exists() or tmp.stat().st_size == 0:
+        tmp.unlink(missing_ok=True)
+        raise HTTPException(status_code=500, detail="video transcode produced no output")
+
+    # Atomic publish — readers only ever see a complete file.
+    os.replace(tmp, dst)
+
+
+def _ensure_web_playable(
+    src: Path,
+    *,
+    repo_id: str | None = None,
+    revision: str | None = None,
+    local_path: str | None = None,
+    rel_path: str = "",
+    hf_token: str | None = None,
+) -> Path:
+    """Return a path to a browser-decodable copy of ``src`` (cached)."""
+    codec, pix_fmt = _probe_video(src)
+    if not _needs_transcode(pix_fmt):
+        return src
+
+    # Grayscale (depth/IR) sources are colorized; the colormap spans the depth
+    # range derived from meta/info.json encoding params (optionally stretched to
+    # observed stats — see _depth_colormap_window).
+    window = _depth_colormap_window(repo_id, revision, local_path, rel_path, hf_token)
+
+    dst = _transcode_cache_path(src, codec, pix_fmt, window)
+    if dst.exists() and dst.stat().st_size > 0:
+        return dst
+
+    with _lock_for(dst.name):
+        # Re-check inside the lock: a concurrent request may have finished
+        # the transcode while we were waiting.
+        if dst.exists() and dst.stat().st_size > 0:
+            return dst
+        logger.info(
+            "transcoding %s (codec=%s pix_fmt=%s window=%s) -> %s",
+            src,
+            codec,
+            pix_fmt,
+            window,
+            dst.name,
+        )
+        _transcode_to_web(src, dst, window)
+    return dst
+
+
 # --- FastAPI app --------------------------------------------------------------
 
 app = FastAPI(title="LeRobot dataset visualizer — annotation backend")
@@ -728,6 +1283,33 @@ def health() -> JSONResponse:
             "event_styles": sorted(EVENT_ONLY_STYLES),
         }
     )
+
+
+@app.get("/api/video/transcode")
+def transcode_video(
+    path: str,
+    repo_id: str | None = None,
+    revision: str | None = None,
+    local_path: str | None = None,
+    hf_token: str | None = None,
+) -> FileResponse:
+    """Serve a browser-decodable copy of a dataset video.
+
+    The frontend calls this only when a <video> element fails to decode the
+    original (e.g. depth cameras stored as gray12le). Web-playable sources are
+    streamed back untouched; everything else is transcoded once and cached.
+    Starlette's FileResponse handles HTTP Range, so seeking works normally.
+    """
+    src = _resolve_video_source(repo_id, revision, local_path, path, hf_token)
+    served = _ensure_web_playable(
+        src,
+        repo_id=repo_id,
+        revision=revision,
+        local_path=local_path,
+        rel_path=path,
+        hf_token=hf_token,
+    )
+    return FileResponse(served, media_type="video/mp4", filename=Path(path).name)
 
 
 @app.post("/api/dataset/load")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ pydantic>=2.5
 pandas>=2.0
 pyarrow>=15
 huggingface_hub>=0.24
+# Optional: enables the /api/video/transcode endpoint (in-process FFmpeg via
+# PyAV; the wheels bundle FFmpeg, so no separate system install is needed).
+av>=12

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,5 @@ pydantic>=2.5
 pandas>=2.0
 pyarrow>=15
 huggingface_hub>=0.24
-# Optional: enables the /api/video/transcode endpoint (in-process FFmpeg via
-# PyAV; the wheels bundle FFmpeg, so no separate system install is needed).
+# Optional: enables /api/video/transcode (in-process FFmpeg via PyAV).
 av>=12

--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -5,6 +5,7 @@ import { useTime } from "../context/time-context";
 import { FaExpand, FaCompress, FaTimes, FaEye } from "react-icons/fa";
 import type { VideoInfo } from "@/types";
 import { proxyHfUrl } from "@/utils/auth";
+import { getTranscodeUrl, isLikelyDepthCamera } from "@/utils/videoClient";
 import { VideoOverlayCanvas } from "./video-overlay-canvas";
 
 const THRESHOLDS = {
@@ -57,6 +58,16 @@ export const SimpleVideosPlayer = ({
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);
   const [showHiddenMenu, setShowHiddenMenu] = React.useState(false);
   const [videosReady, setVideosReady] = React.useState(false);
+  // Filenames whose native decode failed (e.g. depth cameras stored as
+  // gray12le). For these we swap the <video> src to the backend transcode
+  // endpoint, which serves a browser-friendly H.264 copy. Empty unless a
+  // decode error actually fires AND a transcode backend is configured.
+  const [transcodeFallbacks, setTranscodeFallbacks] = React.useState<
+    Set<string>
+  >(() => new Set());
+  // Tracks which fallbacks we've already pushed to the element via load(), so
+  // the apply-effect doesn't repeatedly reload the same video.
+  const appliedFallbackRef = useRef<Set<string>>(new Set());
 
   const hiddenSet = React.useMemo(() => new Set(hiddenVideos), [hiddenVideos]);
 
@@ -92,6 +103,13 @@ export const SimpleVideosPlayer = ({
   useEffect(() => {
     onVideosReadyRef.current = onVideosReady;
   }, [onVideosReady]);
+
+  // Mirror isPlaying so the transcode-apply effect can re-assert play() after
+  // load() without depending on isPlaying (which would churn the effect).
+  const isPlayingRef = useRef(isPlaying);
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
 
   // Initialize video refs array
   useEffect(() => {
@@ -142,6 +160,14 @@ export const SimpleVideosPlayer = ({
       if (!video) return;
       const info = videosInfo[index];
 
+      // Count this camera toward readiness at most once.
+      let counted = false;
+      const countReadyOnce = () => {
+        if (counted) return;
+        counted = true;
+        checkReady();
+      };
+
       // One timeupdate handler per video covers both jobs:
       // (a) loop-reset on segmented videos at segment-end
       // (b) reporting the primary video's currentTime back to the context
@@ -190,8 +216,25 @@ export const SimpleVideosPlayer = ({
 
       const handleLoadedData = info.isSegmented
         ? () => {
+            // Seek into the episode's segment. We deliberately DON'T count
+            // readiness here: loadeddata only guarantees the first frame at
+            // position 0, but segmented v3 cameras share one big file and the
+            // byte-range at segmentStart still has to be fetched. Counting now
+            // lets play() start before that range arrives — the camera then
+            // shows a black/stale frame while a luckier camera plays ahead.
             video.currentTime = info.segmentStart ?? 0;
-            checkReady();
+          }
+        : null;
+
+      // A segmented camera is only ready once it can actually play AT the
+      // seeked segment offset: the seek has finished (!seeking) and it's
+      // buffered to HAVE_FUTURE_DATA. Driven by canplay/seeked below.
+      const handleSegmentReady = info.isSegmented
+        ? () => {
+            if (video.seeking) return;
+            if (video.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA) {
+              countReadyOnce();
+            }
           }
         : null;
 
@@ -217,17 +260,24 @@ export const SimpleVideosPlayer = ({
       // readyState synchronously and mark ready in a microtask. Without this,
       // checkReady wouldn't be called and only the 10s fallback timeout would
       // eventually unfreeze the UI.
-      if (info.isSegmented && handleLoadedData) {
+      if (info.isSegmented && handleLoadedData && handleSegmentReady) {
         if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
           queueMicrotask(handleLoadedData);
+          // Cover the already-buffered case: when segmentStart needs no seek
+          // (or its data is already cached) canplay/seeked won't re-fire.
+          queueMicrotask(handleSegmentReady);
         } else {
           video.addEventListener("loadeddata", handleLoadedData);
         }
+        // canplay fires once the post-seek buffer is playable; seeked covers a
+        // segmentStart whose data is already fully cached (no canplay re-fire).
+        video.addEventListener("canplay", handleSegmentReady);
+        video.addEventListener("seeked", handleSegmentReady);
       } else if (!info.isSegmented) {
         if (video.readyState >= HTMLMediaElement.HAVE_ENOUGH_DATA) {
-          queueMicrotask(checkReady);
+          queueMicrotask(countReadyOnce);
         } else {
-          video.addEventListener("canplaythrough", checkReady, { once: true });
+          video.addEventListener("canplaythrough", countReadyOnce);
         }
       }
 
@@ -237,7 +287,12 @@ export const SimpleVideosPlayer = ({
         if (handleLoadedData)
           video.removeEventListener("loadeddata", handleLoadedData);
         if (handleEnded) video.removeEventListener("ended", handleEnded);
-        video.removeEventListener("canplaythrough", checkReady);
+        if (handleSegmentReady) {
+          video.removeEventListener("canplay", handleSegmentReady);
+          video.removeEventListener("seeked", handleSegmentReady);
+        } else {
+          video.removeEventListener("canplaythrough", countReadyOnce);
+        }
       });
     });
 
@@ -306,6 +361,37 @@ export const SimpleVideosPlayer = ({
     });
   }, [externalSeekVersion, currentTime, videosInfo, videosReady, hiddenSet]);
 
+  // Apply transcode fallbacks: when a filename newly enters the set, React has
+  // already re-rendered the <video> with the backend src; calling load() makes
+  // the element pick it up. We keep the same element (no remount) so the
+  // readiness/loop listeners attached in the big effect above stay live and
+  // fire again for the freshly-loaded transcoded source.
+  useEffect(() => {
+    videoRefs.current.forEach((video, idx) => {
+      if (!video) return;
+      const filename = videosInfo[idx]?.filename;
+      if (!filename) return;
+      if (
+        transcodeFallbacks.has(filename) &&
+        !appliedFallbackRef.current.has(filename)
+      ) {
+        appliedFallbackRef.current.add(filename);
+        video.load();
+        // load() resets the element and aborts any in-flight playback. If the
+        // player is already playing (the global play() fired before this
+        // decode-error reload), nothing else will re-issue play() for this
+        // camera — so it would stay frozen while the others run. Re-assert it.
+        if (isPlayingRef.current) {
+          video.play().catch((e) => {
+            if (e.name !== "AbortError") {
+              console.error("Error playing video");
+            }
+          });
+        }
+      }
+    });
+  }, [transcodeFallbacks, videosInfo]);
+
   return (
     <>
       {/* Hidden videos menu */}
@@ -346,6 +432,17 @@ export const SimpleVideosPlayer = ({
           if (hiddenVideos.includes(info.filename)) return null;
 
           const isEnlarged = enlargedVideo === info.filename;
+          // Depth cameras are routed through the transcode endpoint proactively
+          // (the browser may decode them natively as flat grayscale, so the
+          // onError fallback would never fire and the colormap never apply).
+          // Other cameras only switch to transcode after a decode error.
+          const wantsTranscode =
+            isLikelyDepthCamera(info.filename) ||
+            transcodeFallbacks.has(info.filename);
+          const transcodeUrl = wantsTranscode
+            ? getTranscodeUrl(info.url)
+            : null;
+          const videoSrc = transcodeUrl ?? proxyHfUrl(info.url);
 
           return (
             <div
@@ -404,8 +501,21 @@ export const SimpleVideosPlayer = ({
                   muted
                   preload="auto"
                   crossOrigin="anonymous"
+                  src={videoSrc}
+                  onError={() => {
+                    // Decode failure (e.g. gray12le depth video). Fall back to
+                    // the backend transcode endpoint once, if available. When
+                    // no backend is configured getTranscodeUrl returns null and
+                    // we leave the original error in place (same as before).
+                    if (transcodeFallbacks.has(info.filename)) return;
+                    if (!getTranscodeUrl(info.url)) return;
+                    setTranscodeFallbacks((prev) => {
+                      const next = new Set(prev);
+                      next.add(info.filename);
+                      return next;
+                    });
+                  }}
                 >
-                  <source src={proxyHfUrl(info.url)} type="video/mp4" />
                   Your browser does not support the video tag.
                 </video>
                 {/* VQA bbox/keypoint overlay. Reads atoms + drawMode from

--- a/src/components/simple-videos-player.tsx
+++ b/src/components/simple-videos-player.tsx
@@ -58,15 +58,12 @@ export const SimpleVideosPlayer = ({
   const [enlargedVideo, setEnlargedVideo] = React.useState<string | null>(null);
   const [showHiddenMenu, setShowHiddenMenu] = React.useState(false);
   const [videosReady, setVideosReady] = React.useState(false);
-  // Filenames whose native decode failed (e.g. depth cameras stored as
-  // gray12le). For these we swap the <video> src to the backend transcode
-  // endpoint, which serves a browser-friendly H.264 copy. Empty unless a
-  // decode error actually fires AND a transcode backend is configured.
+  // Filenames whose native decode failed; their <video> src is swapped to the
+  // backend transcode endpoint.
   const [transcodeFallbacks, setTranscodeFallbacks] = React.useState<
     Set<string>
   >(() => new Set());
-  // Tracks which fallbacks we've already pushed to the element via load(), so
-  // the apply-effect doesn't repeatedly reload the same video.
+  // Fallbacks already pushed via load(), so the effect doesn't reload twice.
   const appliedFallbackRef = useRef<Set<string>>(new Set());
 
   const hiddenSet = React.useMemo(() => new Set(hiddenVideos), [hiddenVideos]);
@@ -104,8 +101,8 @@ export const SimpleVideosPlayer = ({
     onVideosReadyRef.current = onVideosReady;
   }, [onVideosReady]);
 
-  // Mirror isPlaying so the transcode-apply effect can re-assert play() after
-  // load() without depending on isPlaying (which would churn the effect).
+  // Mirror isPlaying so the transcode-apply effect can re-assert play() without
+  // depending on it.
   const isPlayingRef = useRef(isPlaying);
   useEffect(() => {
     isPlayingRef.current = isPlaying;
@@ -160,7 +157,6 @@ export const SimpleVideosPlayer = ({
       if (!video) return;
       const info = videosInfo[index];
 
-      // Count this camera toward readiness at most once.
       let counted = false;
       const countReadyOnce = () => {
         if (counted) return;
@@ -216,19 +212,14 @@ export const SimpleVideosPlayer = ({
 
       const handleLoadedData = info.isSegmented
         ? () => {
-            // Seek into the episode's segment. We deliberately DON'T count
-            // readiness here: loadeddata only guarantees the first frame at
-            // position 0, but segmented v3 cameras share one big file and the
-            // byte-range at segmentStart still has to be fetched. Counting now
-            // lets play() start before that range arrives — the camera then
-            // shows a black/stale frame while a luckier camera plays ahead.
+            // Seek into the segment; readiness is counted later, once the
+            // byte-range at segmentStart is buffered (counting now would let
+            // play() start on a black frame for shared v3 segment files).
             video.currentTime = info.segmentStart ?? 0;
           }
         : null;
 
-      // A segmented camera is only ready once it can actually play AT the
-      // seeked segment offset: the seek has finished (!seeking) and it's
-      // buffered to HAVE_FUTURE_DATA. Driven by canplay/seeked below.
+      // Ready only once the seek finished and the segment offset is buffered.
       const handleSegmentReady = info.isSegmented
         ? () => {
             if (video.seeking) return;
@@ -263,14 +254,11 @@ export const SimpleVideosPlayer = ({
       if (info.isSegmented && handleLoadedData && handleSegmentReady) {
         if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
           queueMicrotask(handleLoadedData);
-          // Cover the already-buffered case: when segmentStart needs no seek
-          // (or its data is already cached) canplay/seeked won't re-fire.
+          // Already-buffered case: canplay/seeked won't re-fire.
           queueMicrotask(handleSegmentReady);
         } else {
           video.addEventListener("loadeddata", handleLoadedData);
         }
-        // canplay fires once the post-seek buffer is playable; seeked covers a
-        // segmentStart whose data is already fully cached (no canplay re-fire).
         video.addEventListener("canplay", handleSegmentReady);
         video.addEventListener("seeked", handleSegmentReady);
       } else if (!info.isSegmented) {
@@ -361,11 +349,8 @@ export const SimpleVideosPlayer = ({
     });
   }, [externalSeekVersion, currentTime, videosInfo, videosReady, hiddenSet]);
 
-  // Apply transcode fallbacks: when a filename newly enters the set, React has
-  // already re-rendered the <video> with the backend src; calling load() makes
-  // the element pick it up. We keep the same element (no remount) so the
-  // readiness/loop listeners attached in the big effect above stay live and
-  // fire again for the freshly-loaded transcoded source.
+  // When a filename newly enters the set, load() makes the element pick up the
+  // already-rendered backend src (same element, so listeners stay attached).
   useEffect(() => {
     videoRefs.current.forEach((video, idx) => {
       if (!video) return;
@@ -377,10 +362,8 @@ export const SimpleVideosPlayer = ({
       ) {
         appliedFallbackRef.current.add(filename);
         video.load();
-        // load() resets the element and aborts any in-flight playback. If the
-        // player is already playing (the global play() fired before this
-        // decode-error reload), nothing else will re-issue play() for this
-        // camera — so it would stay frozen while the others run. Re-assert it.
+        // load() aborts playback; re-assert play() so this camera isn't frozen
+        // while the others run.
         if (isPlayingRef.current) {
           video.play().catch((e) => {
             if (e.name !== "AbortError") {
@@ -432,10 +415,8 @@ export const SimpleVideosPlayer = ({
           if (hiddenVideos.includes(info.filename)) return null;
 
           const isEnlarged = enlargedVideo === info.filename;
-          // Depth cameras are routed through the transcode endpoint proactively
-          // (the browser may decode them natively as flat grayscale, so the
-          // onError fallback would never fire and the colormap never apply).
-          // Other cameras only switch to transcode after a decode error.
+          // Depth cameras: route proactively (no decode error fires). Others:
+          // only after onError.
           const wantsTranscode =
             isLikelyDepthCamera(info.filename) ||
             transcodeFallbacks.has(info.filename);
@@ -503,10 +484,7 @@ export const SimpleVideosPlayer = ({
                   crossOrigin="anonymous"
                   src={videoSrc}
                   onError={() => {
-                    // Decode failure (e.g. gray12le depth video). Fall back to
-                    // the backend transcode endpoint once, if available. When
-                    // no backend is configured getTranscodeUrl returns null and
-                    // we leave the original error in place (same as before).
+                    // Fall back to the transcode endpoint once, if configured.
                     if (transcodeFallbacks.has(info.filename)) return;
                     if (!getTranscodeUrl(info.url)) return;
                     setTranscodeFallbacks((prev) => {

--- a/src/utils/__tests__/videoClient.test.ts
+++ b/src/utils/__tests__/videoClient.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseHfDatasetUrl,
+  buildTranscodeUrl,
+  isLikelyDepthCamera,
+} from "@/utils/videoClient";
+
+describe("isLikelyDepthCamera", () => {
+  test("matches depth camera keys", () => {
+    expect(isLikelyDepthCamera("observation.images.top_depth")).toBe(true);
+    expect(isLikelyDepthCamera("observation.images.wrist_depth")).toBe(true);
+    expect(isLikelyDepthCamera("Depth_Camera")).toBe(true);
+  });
+
+  test("does not match regular camera keys", () => {
+    expect(isLikelyDepthCamera("observation.images.wrist")).toBe(false);
+    expect(isLikelyDepthCamera("observation.images.front")).toBe(false);
+  });
+});
+
+describe("parseHfDatasetUrl", () => {
+  test("parses a v3 segmented video URL", () => {
+    const url =
+      "https://huggingface.co/datasets/lerobot/svla_so101/resolve/main/videos/observation.images.front/chunk-000/file-000.mp4";
+    expect(parseHfDatasetUrl(url)).toEqual({
+      repoId: "lerobot/svla_so101",
+      revision: "main",
+      path: "videos/observation.images.front/chunk-000/file-000.mp4",
+    });
+  });
+
+  test("parses a v2 per-episode video URL", () => {
+    const url =
+      "https://huggingface.co/datasets/org/ds/resolve/main/videos/chunk-000/observation.images.cam/episode_000042.mp4";
+    expect(parseHfDatasetUrl(url)).toEqual({
+      repoId: "org/ds",
+      revision: "main",
+      path: "videos/chunk-000/observation.images.cam/episode_000042.mp4",
+    });
+  });
+
+  test("keeps a non-main revision", () => {
+    const url =
+      "https://huggingface.co/datasets/org/ds/resolve/v2.1/videos/x/file.mp4";
+    expect(parseHfDatasetUrl(url)?.revision).toBe("v2.1");
+  });
+
+  test("returns null for an already-proxied same-origin path", () => {
+    expect(
+      parseHfDatasetUrl("/api/proxy/datasets/org/ds/resolve/main/x.mp4"),
+    ).toBeNull();
+  });
+
+  test("returns null for a non-dataset HF URL", () => {
+    expect(
+      parseHfDatasetUrl("https://huggingface.co/org/ds/resolve/main/x.mp4"),
+    ).toBeNull();
+  });
+
+  test("returns null for garbage input", () => {
+    expect(parseHfDatasetUrl("not a url")).toBeNull();
+  });
+});
+
+describe("buildTranscodeUrl", () => {
+  const hfUrl =
+    "https://huggingface.co/datasets/lerobot/depth/resolve/main/videos/observation.images.depth/chunk-000/file-000.mp4";
+
+  test("builds the backend endpoint with query params", () => {
+    const out = buildTranscodeUrl("http://127.0.0.1:7861", hfUrl);
+    const parsed = new URL(out!);
+    expect(parsed.origin).toBe("http://127.0.0.1:7861");
+    expect(parsed.pathname).toBe("/api/video/transcode");
+    expect(parsed.searchParams.get("repo_id")).toBe("lerobot/depth");
+    expect(parsed.searchParams.get("revision")).toBe("main");
+    expect(parsed.searchParams.get("path")).toBe(
+      "videos/observation.images.depth/chunk-000/file-000.mp4",
+    );
+    expect(parsed.searchParams.has("hf_token")).toBe(false);
+  });
+
+  test("forwards an HF token when provided", () => {
+    const out = buildTranscodeUrl("http://127.0.0.1:7861", hfUrl, "hf_abc123");
+    expect(new URL(out!).searchParams.get("hf_token")).toBe("hf_abc123");
+  });
+
+  test("respects a backend base that includes a path prefix", () => {
+    const out = buildTranscodeUrl("http://localhost:7861/", hfUrl);
+    expect(new URL(out!).pathname).toBe("/api/video/transcode");
+  });
+
+  test("returns null when the HF URL can't be parsed", () => {
+    expect(buildTranscodeUrl("http://127.0.0.1:7861", "not a url")).toBeNull();
+  });
+});

--- a/src/utils/videoClient.ts
+++ b/src/utils/videoClient.ts
@@ -1,30 +1,14 @@
 /**
- * Helpers for serving videos the browser can't decode natively (e.g. depth
- * cameras encoded as `gray12le`/`gray16le`) through the optional FastAPI
- * backend's lazy transcode endpoint (`/api/video/transcode`).
- *
- * The hot path is untouched: videos still stream directly from Hugging Face
- * via `/api/proxy`. Only when a `<video>` element fails to decode do we fall
- * back to the backend, which transcodes once to browser-friendly H.264
- * (`yuv420p`), caches the result on disk, and serves it with Range support.
- *
- * When the backend is not configured these helpers return `null`, so the UI
- * behaves exactly as before (unsupported videos simply fail to play).
+ * Helpers for routing videos the browser can't decode (e.g. depth cameras in
+ * `gray12le`) through the optional backend transcode endpoint. When no backend
+ * is configured the helpers return `null` and the UI behaves as before.
  */
 
 import { getAnnotateBackendUrl } from "./annotationsClient";
 import { getAuthToken } from "./auth";
 
-/**
- * Heuristic: does this camera key look like a depth/IR stream?
- *
- * Depth videos are usually stored in pixel formats (e.g. gray12le) or codecs
- * (HEVC) that some browsers decode natively as flat grayscale — so an
- * error-driven transcode fallback never fires for them. We instead route
- * likely-depth cameras through the backend transcode endpoint proactively so
- * the viridis colormap is always applied. Matches keys like
- * `observation.images.top_depth`, `depth_camera`, `wrist_depth`, etc.
- */
+// Depth/IR streams render as flat grayscale (no decode error), so we route
+// them through the colormap transcode proactively rather than on error.
 export function isLikelyDepthCamera(filename: string): boolean {
   return /depth/i.test(filename);
 }
@@ -35,15 +19,8 @@ export interface ParsedHfDatasetUrl {
   path: string;
 }
 
-/**
- * Parse a Hugging Face dataset resolve URL into its parts.
- *
- * Expected shape (produced by `buildVersionedUrl`):
- *   https://huggingface.co/datasets/{org}/{dataset}/resolve/{revision}/{path}
- *
- * Returns `null` for any URL that doesn't match (e.g. already-proxied
- * same-origin URLs, or non-dataset hosts).
- */
+// Parses https://huggingface.co/datasets/{org}/{dataset}/resolve/{rev}/{path};
+// returns null for anything that isn't an HF dataset resolve URL.
 export function parseHfDatasetUrl(url: string): ParsedHfDatasetUrl | null {
   let parsed: URL;
   try {
@@ -51,8 +28,6 @@ export function parseHfDatasetUrl(url: string): ParsedHfDatasetUrl | null {
   } catch {
     return null;
   }
-  // repoId is `org/dataset` (non-greedy so it stops at the first `/resolve/`).
-  // revision is a single path segment; path is everything after it.
   const match = parsed.pathname.match(
     /^\/datasets\/(.+?)\/resolve\/([^/]+)\/(.+)$/,
   );
@@ -66,16 +41,6 @@ export function parseHfDatasetUrl(url: string): ParsedHfDatasetUrl | null {
   };
 }
 
-/**
- * Build the backend transcode URL for a given HF dataset video URL.
- *
- * `backendBase` is the configured annotate-backend origin. `hfToken`, when
- * present, is forwarded so private datasets can be downloaded server-side
- * (the native `<video>` element can't send an Authorization header, so it
- * has to travel as a query param).
- *
- * Returns `null` when the URL can't be parsed.
- */
 export function buildTranscodeUrl(
   backendBase: string,
   hfUrl: string,
@@ -92,16 +57,11 @@ export function buildTranscodeUrl(
   out.searchParams.set("repo_id", parsed.repoId);
   out.searchParams.set("revision", parsed.revision);
   out.searchParams.set("path", parsed.path);
+  // <video> can't send an Authorization header, so the token rides as a param.
   if (hfToken) out.searchParams.set("hf_token", hfToken);
   return out.toString();
 }
 
-/**
- * Resolve the transcode fallback URL for a video, using the configured
- * backend and the signed-in user's HF token. Returns `null` when the backend
- * is not configured or the URL can't be parsed — callers should treat that as
- * "no fallback available" and leave the original load error in place.
- */
 export function getTranscodeUrl(hfUrl: string): string | null {
   const base = getAnnotateBackendUrl();
   if (!base) return null;

--- a/src/utils/videoClient.ts
+++ b/src/utils/videoClient.ts
@@ -1,0 +1,109 @@
+/**
+ * Helpers for serving videos the browser can't decode natively (e.g. depth
+ * cameras encoded as `gray12le`/`gray16le`) through the optional FastAPI
+ * backend's lazy transcode endpoint (`/api/video/transcode`).
+ *
+ * The hot path is untouched: videos still stream directly from Hugging Face
+ * via `/api/proxy`. Only when a `<video>` element fails to decode do we fall
+ * back to the backend, which transcodes once to browser-friendly H.264
+ * (`yuv420p`), caches the result on disk, and serves it with Range support.
+ *
+ * When the backend is not configured these helpers return `null`, so the UI
+ * behaves exactly as before (unsupported videos simply fail to play).
+ */
+
+import { getAnnotateBackendUrl } from "./annotationsClient";
+import { getAuthToken } from "./auth";
+
+/**
+ * Heuristic: does this camera key look like a depth/IR stream?
+ *
+ * Depth videos are usually stored in pixel formats (e.g. gray12le) or codecs
+ * (HEVC) that some browsers decode natively as flat grayscale — so an
+ * error-driven transcode fallback never fires for them. We instead route
+ * likely-depth cameras through the backend transcode endpoint proactively so
+ * the viridis colormap is always applied. Matches keys like
+ * `observation.images.top_depth`, `depth_camera`, `wrist_depth`, etc.
+ */
+export function isLikelyDepthCamera(filename: string): boolean {
+  return /depth/i.test(filename);
+}
+
+export interface ParsedHfDatasetUrl {
+  repoId: string;
+  revision: string;
+  path: string;
+}
+
+/**
+ * Parse a Hugging Face dataset resolve URL into its parts.
+ *
+ * Expected shape (produced by `buildVersionedUrl`):
+ *   https://huggingface.co/datasets/{org}/{dataset}/resolve/{revision}/{path}
+ *
+ * Returns `null` for any URL that doesn't match (e.g. already-proxied
+ * same-origin URLs, or non-dataset hosts).
+ */
+export function parseHfDatasetUrl(url: string): ParsedHfDatasetUrl | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  // repoId is `org/dataset` (non-greedy so it stops at the first `/resolve/`).
+  // revision is a single path segment; path is everything after it.
+  const match = parsed.pathname.match(
+    /^\/datasets\/(.+?)\/resolve\/([^/]+)\/(.+)$/,
+  );
+  if (!match) return null;
+  const [, repoId, revision, path] = match;
+  if (!repoId || !revision || !path) return null;
+  return {
+    repoId: decodeURIComponent(repoId),
+    revision: decodeURIComponent(revision),
+    path: decodeURIComponent(path),
+  };
+}
+
+/**
+ * Build the backend transcode URL for a given HF dataset video URL.
+ *
+ * `backendBase` is the configured annotate-backend origin. `hfToken`, when
+ * present, is forwarded so private datasets can be downloaded server-side
+ * (the native `<video>` element can't send an Authorization header, so it
+ * has to travel as a query param).
+ *
+ * Returns `null` when the URL can't be parsed.
+ */
+export function buildTranscodeUrl(
+  backendBase: string,
+  hfUrl: string,
+  hfToken?: string | null,
+): string | null {
+  const parsed = parseHfDatasetUrl(hfUrl);
+  if (!parsed) return null;
+  let out: URL;
+  try {
+    out = new URL("/api/video/transcode", backendBase);
+  } catch {
+    return null;
+  }
+  out.searchParams.set("repo_id", parsed.repoId);
+  out.searchParams.set("revision", parsed.revision);
+  out.searchParams.set("path", parsed.path);
+  if (hfToken) out.searchParams.set("hf_token", hfToken);
+  return out.toString();
+}
+
+/**
+ * Resolve the transcode fallback URL for a video, using the configured
+ * backend and the signed-in user's HF token. Returns `null` when the backend
+ * is not configured or the URL can't be parsed — callers should treat that as
+ * "no fallback available" and leave the original load error in place.
+ */
+export function getTranscodeUrl(hfUrl: string): string | null {
+  const base = getAnnotateBackendUrl();
+  if (!base) return null;
+  return buildTranscodeUrl(base, hfUrl, getAuthToken());
+}


### PR DESCRIPTION
## Summary

- Adds an optional FastAPI backend endpoint (`/api/video/transcode`) that serves browser-decodable copies of dataset videos. Only **grayscale** depth/IR pixel formats (e.g. `gray12le`/`gray16le`) are transcoded — to `yuv420p` H.264 with a viridis colormap via in-process PyAV — then cached on disk (keyed by source identity) and served with depth range support (inferred from percentiles). Every other source, including AV1/HEVC RGB, is served untouched so the common path never re-encodes.
- Wires the frontend `<video>` players to fall back to that endpoint on native decode failure, and routes depth-named cameras through it proactively (some browsers decode `gray12le` as flat grayscale without erroring, so the colormap would otherwise never apply).
- Adds `videoClient` helpers (HF URL parsing, transcode-URL builder, depth-camera heuristic) with unit tests. When no backend is configured the helpers return `null` and behavior is unchanged.

## Notes

- Limiting transcoding to grayscale keeps CPU load minimal: libx264 only runs for actual depth videos, not for every RGB shard.
- Trade-off: RGB sources that a given browser can't decode natively (e.g. AV1 on older browsers) are no longer re-encoded and will rely on native decode.

## Test plan

- [x] `bun run validate` (type-check + lint + format:check + test) — 144 tests pass
- [ ] Load a dataset with `gray12le` depth cameras and confirm the colormap renders
- [ ] Load an H.264 RGB dataset and confirm videos stream directly from HF (no transcode, no backend hit)
- [ ] Confirm behavior is unchanged when the annotate backend is not configured

Made with [Cursor](https://cursor.com)