### PR TITLE
fix(urdf): load so101 URDF for so100 datasets

### DIFF
--- a/src/components/urdf-viewer.tsx
+++ b/src/components/urdf-viewer.tsx
@@ -53,9 +53,6 @@ function getRobotConfig(robotType: string | null) {
       scale: 3,
     };
   }
-  if (lower.includes("so100") && !lower.includes("so101")) {
-    return { urdfUrl: `${URDF_BASE_URL}/so101/so100.urdf`, scale: 10 };
-  }
   return {
     urdfUrl: `${URDF_BASE_URL}/so101/so101_new_calib.urdf`,
     scale: 10,


### PR DESCRIPTION
## What

`getRobotConfig` in `src/components/urdf-viewer.tsx` had a special case that loaded `so100.urdf` for `so100` datasets. This removes that branch so `so100` datasets fall through to the default and load `so101_new_calib.urdf`, same as `so101` datasets.

## Why

We want to render the SO-101 model for SO-100 datasets.

## Notes

- `g1`/`unitree` and `openarm` robot types are unaffected.
- The `so100.urdf` bucket asset is now unreferenced; left in place (bucket assets are out of scope for this change).

## Validation

`bun run format && bun run validate` — type-check, lint, format-check, and all 152 tests pass.