### PR TITLE
fix(annotations): render v3.1 language atoms on v2.x datasets

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/__tests__/fetch-data.test.ts
+++ b/src/app/[org]/[dataset]/[episode]/__tests__/fetch-data.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { computeColumnMinMax } from "@/app/[org]/[dataset]/[episode]/fetch-data";
+import {
+  computeColumnMinMax,
+  extractLanguageAtoms,
+} from "@/app/[org]/[dataset]/[episode]/fetch-data";
 import type { ChartRow } from "@/app/[org]/[dataset]/[episode]/fetch-data";
 
 // ---------------------------------------------------------------------------
@@ -110,6 +113,74 @@ describe("computeColumnMinMax — nested group values (grouped suffix format)", 
     expect(colMap["action | 0"].min).toBe(-1.0);
     expect(colMap["action | 0"].max).toBe(-1.0);
     expect(colMap["action | 1"].min).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractLanguageAtoms
+// v3.1 language atoms (lerobot#3467) live in the `language_persistent` and
+// `language_events` parquet columns. lerobot can write these onto v2.x datasets
+// (codebase_version stays 2.x), so BOTH the v2 and v3 loaders must extract them.
+// These tests pin the extraction shape that both loaders rely on.
+// ---------------------------------------------------------------------------
+
+describe("extractLanguageAtoms", () => {
+  test("returns [] for empty rows (un-annotated dataset)", () => {
+    expect(extractLanguageAtoms([])).toEqual([]);
+  });
+
+  test("returns [] when the language columns are absent (plain v2 rows)", () => {
+    // A v2.x parquet with no annotations has no language_* columns; requesting
+    // them is a no-op in hyparquet, so rows arrive without those keys.
+    const rows = [
+      { timestamp: 0, "observation.state": [0.1] },
+      { timestamp: 0.1, "observation.state": [0.2] },
+    ];
+    expect(extractLanguageAtoms(rows)).toEqual([]);
+  });
+
+  test("reads a persistent (broadcast) atom once, deduped across rows", () => {
+    const persistent = [
+      { role: "annotator", content: "fold the shirt", style: "subtask" },
+    ];
+    // Broadcast: the same list is present on every row of the episode.
+    const rows = [
+      { timestamp: 0, language_persistent: persistent, language_events: [] },
+      { timestamp: 0.1, language_persistent: persistent, language_events: [] },
+      { timestamp: 0.2, language_persistent: persistent, language_events: [] },
+    ];
+    const atoms = extractLanguageAtoms(rows);
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0].style).toBe("subtask");
+    expect(atoms[0].content).toBe("fold the shirt");
+  });
+
+  test("collects per-row events and falls back to the frame timestamp", () => {
+    const rows = [
+      { timestamp: 0, language_persistent: [], language_events: [] },
+      {
+        timestamp: 1.5,
+        language_persistent: [],
+        // Event rows omit their own timestamp — the frame timestamp is the
+        // firing time and must be back-filled.
+        language_events: [{ role: "user", content: "how many?", style: "vqa" }],
+      },
+    ];
+    const atoms = extractLanguageAtoms(rows);
+    expect(atoms).toHaveLength(1);
+    expect(atoms[0].style).toBe("vqa");
+    expect(atoms[0].timestamp).toBe(1.5);
+  });
+
+  test("drops malformed atoms missing a role", () => {
+    const rows = [
+      {
+        timestamp: 0,
+        language_persistent: [{ content: "no role here", style: "plan" }],
+        language_events: [],
+      },
+    ];
+    expect(extractLanguageAtoms(rows)).toEqual([]);
   });
 });
 

--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -585,10 +585,34 @@ async function getEpisodeDataV2(
       "task",
       "task_index",
       "language_instruction",
+      // v3.1 language schema (lerobot#3467) — list<struct{...}> columns the
+      // annotations panel renders / edits. lerobot can write these onto v2.x
+      // datasets too (the codebase_version stays 2.x), so a v2 episode may
+      // carry annotations. Requesting columns absent from the parquet schema
+      // is a no-op in hyparquet, so this is safe for un-annotated datasets.
+      "language_persistent",
+      "language_events",
       ...filteredColumns.map((c) => c.key),
     ]),
   );
   const allData = await readParquetAsObjects(arrayBuffer, parquetColumns);
+
+  // Frame timestamps (sorted, seconds) let the annotations editor snap atoms
+  // to exact frames. v3.1 language atoms are broadcast in `language_persistent`
+  // and fired per-row in `language_events`; extract them so annotations written
+  // onto v2.x datasets render in the panel/timeline just like on v3.0.
+  const frameTimestamps = allData
+    .map((r) => {
+      const t = r.timestamp;
+      return typeof t === "number"
+        ? t
+        : typeof t === "bigint"
+          ? Number(t)
+          : Number.NaN;
+    })
+    .filter((t) => Number.isFinite(t))
+    .sort((a, b) => a - b);
+  const languageAtoms = extractLanguageAtoms(allData);
 
   // Extract task from language_instruction fields, task field, or tasks.jsonl
   let task: string | undefined;
@@ -710,6 +734,8 @@ async function getEpisodeDataV2(
     ignoredColumns,
     duration,
     task,
+    languageAtoms,
+    frameTimestamps,
   };
 }
 
@@ -1008,7 +1034,7 @@ async function loadEpisodeDataV3(
  * We coerce loosely-typed values to the canonical `LanguageAtom` shape and
  * drop rows that don't validate.
  */
-function extractLanguageAtoms(
+export function extractLanguageAtoms(
   episodeRows: Record<string, unknown>[],
 ): import("@/types/language.types").LanguageAtom[] {
   if (!episodeRows.length) return [];


### PR DESCRIPTION
## Problem

Annotation jobs succeed and the atoms really do land in the dataset parquet (in the `language_persistent` / `language_events` columns), but the visualizer's **Annotations panel/timeline shows nothing for v2.x datasets**.

Reported by a user: [`nikodembartnik/fold_clothes_dining_annotated`](https://huggingface.co/spaces/lerobot/visualize_dataset?path=%2Fnikodembartnik%2Ffold_clothes_dining_annotated) — a v2.1 dataset — has annotations in `data/chunk-000/episode_000000.parquet` yet the visualizer renders none.

## Root cause

The episode loader dispatches on `codebase_version` into two paths:

- `getEpisodeDataV3()` (v3.0) reads `language_persistent`/`language_events` and calls `extractLanguageAtoms()` → annotations render.
- `getEpisodeDataV2()` (v2.0 / v2.1) **never requested those columns and never extracted atoms**, so it always returned `languageAtoms: undefined`.

The v3.1 language feature (#108) only wired extraction into the v3 path. But lerobot writes the v3.1 language schema (lerobot#3467) onto v2.x datasets too — the `codebase_version` stays `2.x` — so an annotated v2 episode carries the atoms in its parquet while the panel was seeded with nothing.

## Fix

`getEpisodeDataV2()` now mirrors the v3 loader:

1. Requests `language_persistent` + `language_events` in the parquet read.
2. Extracts atoms via the shared, version-agnostic `extractLanguageAtoms()`.
3. Returns them alongside sorted `frameTimestamps` (for the editor's frame snapping).

Requesting columns that are absent from a parquet's schema is a no-op in hyparquet (`parquetPlan` only selects columns present in the row-group metadata), so **un-annotated v2 datasets are unaffected** — no extra data is read and `languageAtoms` comes back empty.

The Annotations tab is already rendered for all versions (unlike the 3D Replay tab, which is v3-gated), so no UI change is needed — v2 datasets were showing an empty panel and now get seeded with their atoms.

## Tests

`extractLanguageAtoms` is now exported and covered by unit tests, including the plain-v2 case where the language columns are absent (proves the no-op path returns `[]` and never throws). Persistent-broadcast dedup, per-row event timestamp fallback, and malformed-atom rejection are also pinned.

`bun run validate` is green: type-check + lint + format clean, 157 tests pass (5 new). Pre-existing ESLint warnings are in unrelated files and untouched.

## Impact

Every already-annotated v2.x dataset will now display its annotations in the visualizer — no need to re-run any annotation jobs.