### PR TITLE
feat(local): Add opt-in local dataset visualization with minimal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+To visualize LeRobot datasets from **local disk**, run `bun run local <path/to/datasets>` — see [docs/local-datasets.md](docs/local-datasets.md).
+
 You can start editing the page by modifying `src/app/page.tsx` or other files in the `src/` directory. The app supports hot-reloading for rapid development.
 
 ### Other Commands

--- a/docs/local-datasets.md
+++ b/docs/local-datasets.md
@@ -1,0 +1,17 @@
+# Visualizing local datasets
+
+View LeRobot datasets straight from **local disk** (instead of the HuggingFace Hub):
+
+```bash
+bun install
+bun run local /path/to/your/datasets      # a dataset dir, or a folder of them
+```
+
+`bun run local` configures and starts the app for you:
+
+- **A single dataset** → `http://localhost:3000/` opens straight on it.
+- **A folder of datasets** → it prints each dataset's URL for you to open.
+
+A "dataset dir" is any folder with `meta/info.json` (LeRobot v2.0 / v2.1 / v3.0). Use a
+different port with `bun run local /path --port 8080`. On a remote machine, forward the
+app port your tooling assigns — that's the only port needed.

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,19 @@ const nextConfig: NextConfig = {
     optimizePackageImports: ["react-icons", "recharts", "@huggingface/hub"],
   },
   generateBuildId: () => packageJson.version,
+  // Local mode only: when `bun run local` points at a single dataset it sets REPO_ID,
+  // and this lands the bare "/" straight on it (server-side, so no client flash). Gated
+  // on LEROBOT_LOCAL_DATASET_ROOTS — which only the local launcher sets — so the hosted
+  // deployment (which never sets it) is unaffected and keeps its normal landing.
+  async redirects() {
+    const repo = process.env.REPO_ID;
+    if (repo && process.env.LEROBOT_LOCAL_DATASET_ROOTS) {
+      return [
+        { source: "/", destination: `/${repo}/episode_0`, permanent: false },
+      ];
+    }
+    return [];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "local": "node scripts/local.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/local.mjs
+++ b/scripts/local.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// One-liner launcher for viewing LOCAL datasets:
+//
+//   bun run local <datasets-dir> [--port N] [...next-dev-args]
+//   LEROBOT_DATASET_ROOT=<dir> bun run local
+//
+// <datasets-dir> is a LeRobot dataset directory (has meta/info.json) or a folder
+// of them. It sets NEXT_PUBLIC_DATASET_URL=/local-data + LEROBOT_LOCAL_DATASET_ROOTS,
+// keeps the listen port and the server self-fetch origin in sync, installs deps on
+// first run, and starts `next dev`. Ctrl-C stops it.
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, statSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+process.chdir(repoRoot);
+
+const argv = process.argv.slice(2);
+const root =
+  argv[0] && !argv[0].startsWith("-")
+    ? argv.shift()
+    : process.env.LEROBOT_DATASET_ROOT;
+
+if (!root) {
+  console.error(
+    "Usage: bun run local <datasets-dir> [--port N] [...next-dev-args]",
+  );
+  console.error("   or: LEROBOT_DATASET_ROOT=<dir> bun run local");
+  process.exit(1);
+}
+const datasetsRoot = path.resolve(root);
+if (!existsSync(datasetsRoot) || !statSync(datasetsRoot).isDirectory()) {
+  console.error(`Not a directory: ${datasetsRoot}`);
+  process.exit(1);
+}
+
+// Extract the port from the forwarded args (or PORT env) so the listen port and the
+// server self-fetch origin (src/utils/dataUrl.ts) always agree — the one thing a bare
+// `--port` flag would otherwise get wrong.
+let port = process.env.PORT;
+for (let i = 0; i < argv.length; i++) {
+  const eq = /^(?:--port|-p)=(\d+)$/.exec(argv[i]);
+  if (eq) port = eq[1];
+  else if ((argv[i] === "--port" || argv[i] === "-p") && argv[i + 1])
+    port = argv[i + 1];
+}
+port = port || "3000";
+
+if (!existsSync(path.join(repoRoot, "node_modules"))) {
+  console.log("Installing dependencies (first run)…");
+  if (spawnSync("bun", ["install"], { stdio: "inherit" }).status !== 0)
+    process.exit(1);
+}
+
+const env = {
+  ...process.env,
+  PORT: port,
+  NEXT_PUBLIC_DATASET_URL: "/local-data",
+  LEROBOT_LOCAL_DATASET_ROOTS: datasetsRoot,
+};
+
+// List the datasets that will be registered, so the terminal is the picker.
+const isDataset = (d) => {
+  try {
+    return statSync(path.join(d, "meta", "info.json")).isFile();
+  } catch {
+    return false;
+  }
+};
+let found;
+try {
+  found = isDataset(datasetsRoot)
+    ? [path.basename(datasetsRoot)]
+    : readdirSync(datasetsRoot).filter((n) =>
+        isDataset(path.join(datasetsRoot, n)),
+      );
+} catch {
+  found = [];
+}
+console.log(`\n  datasets root : ${datasetsRoot}`);
+if (found.length === 1) {
+  // Single dataset: let the bare "/" land straight on it. The landing page already
+  // redirects to /$REPO_ID/episode_0 when REPO_ID is set.
+  env.REPO_ID = `local/${found[0]}`;
+  console.log(`  open http://localhost:${port}/   → ${env.REPO_ID}/episode_0`);
+} else if (found.length > 1) {
+  console.log("  open one in your browser:");
+  for (const name of found.sort())
+    console.log(`    http://localhost:${port}/local/${name}/0`);
+} else {
+  console.log("  (no dataset with meta/info.json found under this path)");
+}
+console.log();
+
+const child = spawn("next", ["dev", ...argv], { stdio: "inherit", env });
+child.on("exit", (code) => process.exit(code ?? 0));
+for (const sig of ["SIGINT", "SIGTERM"]) process.on(sig, () => child.kill(sig));

--- a/src/app/local-data/[...path]/route.ts
+++ b/src/app/local-data/[...path]/route.ts
@@ -1,0 +1,120 @@
+import { open, stat } from "node:fs/promises";
+import { resolveLocalFile } from "@/lib/localDatasets";
+
+// Same-origin file server for LOCAL datasets. Serves
+// `/local-data/{repo}/resolve/{ref}/{path}` from disk with HTTP Range support
+// (hyparquet byte-range reads + <video> seeking). Because it lives in the app,
+// there's no separate process, no CORS, and no data port to forward.
+//
+// Inert on the hosted deployment: resolveLocalFile() returns null when no local
+// registry env is set, so every request 404s. Path traversal is blocked in
+// resolveLocalFile().
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RESOLVE_RE = /^(.+?)\/resolve\/[^/]+\/(.+)$/;
+
+// Only mp4 (needed for <video> playback) and json need a real type; parquet and
+// everything else fall through to the octet-stream default.
+const CONTENT_TYPES: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".json": "application/json",
+};
+
+function contentType(p: string): string {
+  const i = p.lastIndexOf(".");
+  return (
+    (i >= 0 && CONTENT_TYPES[p.slice(i).toLowerCase()]) ||
+    "application/octet-stream"
+  );
+}
+
+function resolvePath(parts: string[]): string | null {
+  const joined = parts.map((s) => decodeURIComponent(s)).join("/");
+  const m = RESOLVE_RE.exec(joined);
+  if (!m) return null;
+  return resolveLocalFile(m[1], m[2]);
+}
+
+function parseRange(
+  header: string | null,
+  size: number,
+): { start: number; end: number } | null | "invalid" {
+  if (!header) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m || (m[1] === "" && m[2] === "")) return null;
+  let start: number;
+  let end: number;
+  if (m[1] === "") {
+    start = Math.max(0, size - Number(m[2]));
+    end = size - 1;
+  } else {
+    start = Number(m[1]);
+    end = m[2] ? Math.min(Number(m[2]), size - 1) : size - 1;
+  }
+  if (start > end || start >= size) return "invalid";
+  return { start, end };
+}
+
+async function serve(
+  req: Request,
+  parts: string[],
+  headOnly: boolean,
+): Promise<Response> {
+  const file = resolvePath(parts);
+  if (!file) return new Response("Not found", { status: 404 });
+
+  let size: number;
+  try {
+    const st = await stat(file);
+    if (!st.isFile()) return new Response("Not found", { status: 404 });
+    size = st.size;
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const rng = parseRange(req.headers.get("range"), size);
+  if (rng === "invalid") {
+    return new Response("Range Not Satisfiable", {
+      status: 416,
+      headers: { "Content-Range": `bytes */${size}` },
+    });
+  }
+  const start = rng ? rng.start : 0;
+  const end = rng ? rng.end : size - 1;
+  const length = end - start + 1;
+
+  const headers = new Headers({
+    "Content-Type": contentType(file),
+    "Content-Length": String(length),
+    "Accept-Ranges": "bytes",
+    "Cache-Control": "no-store",
+  });
+  if (rng) headers.set("Content-Range", `bytes ${start}-${end}/${size}`);
+
+  if (headOnly) return new Response(null, { status: rng ? 206 : 200, headers });
+
+  const fh = await open(file, "r");
+  try {
+    const buf = Buffer.alloc(length);
+    const { bytesRead } = await fh.read(buf, 0, length, start);
+    const body = bytesRead === length ? buf : buf.subarray(0, bytesRead);
+    return new Response(body, { status: rng ? 206 : 200, headers });
+  } finally {
+    await fh.close();
+  }
+}
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  return serve(req, (await ctx.params).path, false);
+}
+
+export async function HEAD(
+  req: Request,
+  ctx: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  return serve(req, (await ctx.params).path, true);
+}

--- a/src/lib/localDatasets.ts
+++ b/src/lib/localDatasets.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Registry of local LeRobot datasets: repo id -> absolute directory.
+ *
+ * Opt-in via `LEROBOT_LOCAL_DATASET_ROOTS` (colon-separated dirs); each child — or the
+ * dir itself — with `meta/info.json` is registered as `local/<basename>`. Empty on the
+ * hosted deployment, so the local-data route handler is inert there (returns 404). Read
+ * fresh on each call so newly added datasets appear without a restart.
+ */
+function isDatasetDir(dir: string): boolean {
+  try {
+    return fs.statSync(path.join(dir, "meta", "info.json")).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function getLocalDatasets(): Record<string, string> {
+  const out: Record<string, string> = {};
+  const roots = (process.env.LEROBOT_LOCAL_DATASET_ROOTS || "")
+    .split(":")
+    .map((r) => r.trim())
+    .filter(Boolean);
+  for (const root of roots) {
+    const absRoot = path.resolve(root);
+    if (isDatasetDir(absRoot)) {
+      out[`local/${path.basename(absRoot)}`] = absRoot;
+      continue;
+    }
+    try {
+      for (const name of fs.readdirSync(absRoot)) {
+        const child = path.join(absRoot, name);
+        if (isDatasetDir(child)) out[`local/${name}`] = child;
+      }
+    } catch {
+      // ignore an unreadable root
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a repo-relative path to an absolute file inside the dataset dir, or
+ * null if the repo is unknown or the path escapes the dir (traversal guard).
+ */
+export function resolveLocalFile(
+  repoId: string,
+  relPath: string,
+): string | null {
+  const base = getLocalDatasets()[repoId.toLowerCase()];
+  if (!base) return null;
+  const target = path.resolve(base, relPath);
+  if (target !== base && !target.startsWith(base + path.sep)) return null;
+  return target;
+}

--- a/src/utils/dataUrl.ts
+++ b/src/utils/dataUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve a dataset asset URL for the current runtime (opt-in local mode).
+ *
+ * In local mode `NEXT_PUBLIC_DATASET_URL` is a same-origin path (e.g. "/local-data",
+ * the in-app route handler), so the browser fetches assets same-origin — no CORS,
+ * no port matching (any tunnelled port works). Node's fetch (server components) needs
+ * an absolute URL, so on the server we prepend the app's OWN local origin — the loopback
+ * address it actually listens on, NOT the public/tunnelled host it can't reach.
+ *
+ * That origin follows the app's port automatically: `next dev`/`next start` honour the
+ * `PORT` env var, and we read the same var, so `PORT=3005 bun dev` needs no extra config.
+ * `LOCAL_SELF_ORIGIN` overrides it (e.g. if you launch with the `--port` flag instead of
+ * the `PORT` env var, or bind a non-loopback host).
+ *
+ * Inert on the hosted deployment: with `NEXT_PUBLIC_DATASET_URL` unset the base is
+ * an absolute `https://huggingface.co/...` URL and takes the early return.
+ */
+const SELF_ORIGIN =
+  process.env.LOCAL_SELF_ORIGIN ||
+  `http://127.0.0.1:${process.env.PORT || "3000"}`;
+
+export function toFetchUrl(url: string): string {
+  if (/^https?:\/\//i.test(url)) return url; // absolute (HF Hub or explicit) — unchanged
+  if (typeof window !== "undefined") return url; // browser: same-origin relative is fine
+  return SELF_ORIGIN + url; // server: absolutise to the app's own route handler
+}

--- a/src/utils/parquetUtils.ts
+++ b/src/utils/parquetUtils.ts
@@ -6,6 +6,7 @@ import {
   type AsyncBuffer,
 } from "hyparquet";
 import { authHeaders } from "./auth";
+import { toFetchUrl } from "./dataUrl";
 
 export interface DatasetMetadata {
   codebase_version: string;
@@ -32,7 +33,7 @@ export interface DatasetMetadata {
 }
 
 export async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, {
+  const res = await fetch(toFetchUrl(url), {
     cache: "no-store",
     headers: authHeaders(),
   });
@@ -61,7 +62,7 @@ export async function fetchParquetFile(url: string): Promise<ParquetFile> {
   if (cached) return cached;
 
   const file = await asyncBufferFromUrl({
-    url,
+    url: toFetchUrl(url),
     requestInit: { cache: "no-store", headers: authHeaders() },
   });
   const wrapped = cachedAsyncBuffer(file);

--- a/src/utils/versionUtils.ts
+++ b/src/utils/versionUtils.ts
@@ -3,9 +3,15 @@
  */
 
 import { authHeaders } from "./auth";
+import { toFetchUrl } from "./dataUrl";
 
+// `NEXT_PUBLIC_DATASET_URL` is browser-visible; in local mode it points at the
+// same-origin `/local-data` route handler. Unset on the hosted deployment, so this
+// falls back to `DATASET_URL` / the Hub default. See docs/local-datasets.md.
 const DATASET_URL =
-  process.env.DATASET_URL || "https://huggingface.co/datasets";
+  process.env.NEXT_PUBLIC_DATASET_URL ||
+  process.env.DATASET_URL ||
+  "https://huggingface.co/datasets";
 
 /**
  * Dataset information structure from info.json
@@ -80,7 +86,7 @@ export async function getDatasetInfo(repoId: string): Promise<DatasetInfo> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-    const response = await fetch(testUrl, {
+    const response = await fetch(toFetchUrl(testUrl), {
       method: "GET",
       cache: "no-store",
       signal: controller.signal,
@@ -138,7 +144,7 @@ export async function getDatasetStats(
     const url = `${DATASET_URL}/${repoId}/resolve/main/meta/stats.json`;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000);
-    const response = await fetch(url, {
+    const response = await fetch(toFetchUrl(url), {
       method: "GET",
       cache: "no-store",
       signal: controller.signal,


### PR DESCRIPTION
## Summary

Opt-in support for visualizing LeRobot datasets from **local disk**, designed as the
**smallest, lowest-risk** way to do it: 

it doesn't touch the landing page or the episode viewer.

```bash
bun install
bun run local /path/to/your/datasets   # a dataset dir, or a folder of them
```

A single dataset opens `/` straight on it; a folder prints each dataset's URL. 

## Minimal by design

The change is almost entirely **additive** — an in-app route handler that serves local
files with HTTP Range, a small registry, and a URL-resolution helper. Changes to existing
files are limited to a `DATASET_URL` fallback and two one-line `fetch` wraps
(`versionUtils.ts` +12, `parquetUtils.ts` +5). **`page.tsx` and `episode-viewer.tsx` are
untouched.**

## Comparison with #53 and #54

| | #53 | #54 | **This PR** |
|---|---|---|---|
| Diff | +957 / −225 (13 files) | +457 / −25 (11 files) | **+349 / −5 (10 files)** |
| Rewrites landing / viewer | landing **and** viewer | landing (+171) | **neither** |
| Open a dataset | paste path in the UI | in-app list + Docker mount | **`bun run local <dir>`** |
| Ports / CORS | — | — | **single-origin, one port (SSH-friendly)** |

All three add local-dataset support; this one optimizes for the smallest

## How it works

- `app/local-data/[...path]/route.ts` serves `/{repo}/resolve/main/{path}` from disk with
  HTTP Range (hyparquet reads + `<video>` seeking) 
- `NEXT_PUBLIC_DATASET_URL=/local-data` makes asset URLs same-origin; `toFetchUrl`
  absolutises to the app's own origin for server-side fetch.
- `bun run local <dir>` sets the env, keeps the port in sync, and (single dataset) lands
  `/` on it via a `next.config` redirect gated to local mode.

With the env unset, the `/local-data` route 404s and the dataset base falls back to the
Hub. Supports LeRobot v2.0 / v2.1 / v3.0.