### PR TITLE
fix(action-insights): NaN speeds no longer produce a false "Consistent" verdict

### DIFF
--- a/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -11,6 +11,7 @@ import {
   getDatasetStats,
 } from "@/utils/versionUtils";
 import { PADDING, CHART_CONFIG, EXCLUDED_COLUMNS } from "@/utils/constants";
+import { episodeMovementScore } from "@/utils/speedStats";
 import {
   processChartDataGroups,
   groupRowBySuffix,
@@ -2135,28 +2136,29 @@ export async function loadCrossEpisodeActionVariance(
   }
 
   // Per-episode average movement per frame: mean L2 norm of frame-to-frame action deltas
+  // NaN-safe (`?? 0` catches null/undefined but NOT NaN): datasets with partial tracking
+  // carry NaN action frames, and one such frame used to turn the whole episode's score —
+  // and then every downstream mean/median — into NaN. episodeMovementScore averages over
+  // the finite frame pairs only, and returns NaN when nothing at all was measurable.
   const movementScores: LowMovementEpisode[] = episodeActions.map(
-    ({ index, actions: ep }) => {
-      if (ep.length < 2) return { episodeIndex: index, totalMovement: 0 };
-      let total = 0;
-      for (let t = 1; t < ep.length; t++) {
-        let sumSq = 0;
-        for (let d = 0; d < actionDim; d++) {
-          const delta = (ep[t][d] ?? 0) - (ep[t - 1][d] ?? 0);
-          sumSq += delta * delta;
-        }
-        total += Math.sqrt(sumSq);
-      }
-      const avgPerFrame = total / (ep.length - 1);
-      return {
-        episodeIndex: index,
-        totalMovement: Math.round(avgPerFrame * 10000) / 10000,
-      };
-    },
+    ({ index, actions: ep }) => ({
+      episodeIndex: index,
+      totalMovement: episodeMovementScore(ep, actionDim),
+    }),
   );
 
-  movementScores.sort((a, b) => a.totalMovement - b.totalMovement);
-  const lowMovementEpisodes = movementScores.slice(0, 10);
+  // NaN-scored episodes (nothing measurable) sort LAST: the comparator is otherwise
+  // undefined on NaN, and an unmeasured episode must not surface as "lowest movement".
+  movementScores.sort(
+    (a, b) =>
+      (Number.isFinite(a.totalMovement) ? a.totalMovement : Infinity) -
+      (Number.isFinite(b.totalMovement) ? b.totalMovement : Infinity),
+  );
+  // Finite only: an episode where nothing was measurable is not a "low movement" episode,
+  // and its NaN would break the section's Math.max/toFixed rendering.
+  const lowMovementEpisodes = movementScores
+    .filter((s) => Number.isFinite(s.totalMovement))
+    .slice(0, 10);
 
   // Precompute per-dimension normalization: motor range (max − min) and unique value count
   const motorRanges: number[] = new Array(actionDim);

--- a/src/components/action-insights-panel.tsx
+++ b/src/components/action-insights-panel.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { useFlaggedEpisodes } from "@/context/flagged-episodes-context";
 import { CHART_CONFIG } from "@/utils/constants";
+import { speedVarianceStats } from "@/utils/speedStats";
 import type {
   CrossEpisodeVarianceData,
   AggVelocityStat,
@@ -1073,60 +1074,89 @@ function SpeedVarianceSection({
   numEpisodes: number;
 }) {
   const isFs = useIsFullscreen();
-  const { speeds, mean, std, cv, median, bins, lo, binW, maxBin, verdict } =
-    useMemo(() => {
-      const sp = distribution.map((d) => d.speed).sort((a, b) => a - b);
-      const m = sp.reduce((a, b) => a + b, 0) / sp.length;
-      const s = Math.sqrt(sp.reduce((a, v) => a + (v - m) ** 2, 0) / sp.length);
-      const c = m > 0 ? s / m : 0;
-      const med = sp[Math.floor(sp.length / 2)];
+  const {
+    speeds,
+    dropped,
+    mean,
+    std,
+    cv,
+    median,
+    bins,
+    lo,
+    binW,
+    maxBin,
+    verdict,
+  } = useMemo(() => {
+    // NaN-safe: partial-tracking datasets carry NaN speeds, and a plain mean/std over
+    // them is NaN — after which `NaN > 0` is false, cv silently became 0, and the
+    // verdict rendered a green "Consistent" computed from no data at all. Stats now
+    // come from the finite entries only, and the dropped count is shown to the user.
+    const {
+      speeds: sp,
+      dropped,
+      mean: m,
+      std: s,
+      cv: c,
+      median: med,
+    } = speedVarianceStats(distribution.map((d) => d.speed));
 
-      const binCount = Math.min(30, Math.ceil(Math.sqrt(sp.length)));
-      const lo = sp[0],
-        hi = sp[sp.length - 1];
-      const bw = (hi - lo || 1) / binCount;
-      const b = new Array(binCount).fill(0);
-      for (const v of sp) {
-        let i = Math.floor((v - lo) / bw);
-        if (i >= binCount) i = binCount - 1;
-        b[i]++;
-      }
+    const binCount = Math.min(30, Math.ceil(Math.sqrt(sp.length)));
+    const lo = sp[0],
+      hi = sp[sp.length - 1];
+    const bw = (hi - lo || 1) / binCount;
+    const b = new Array(binCount).fill(0);
+    for (const v of sp) {
+      let i = Math.floor((v - lo) / bw);
+      if (i >= binCount) i = binCount - 1;
+      b[i]++;
+    }
 
-      let v: { label: string; color: string; tip: string };
-      if (c < 0.2)
-        v = {
-          label: "Consistent",
-          color: "text-green-400",
-          tip: "Demonstrators execute at similar speeds — no velocity normalization needed.",
-        };
-      else if (c < 0.4)
-        v = {
-          label: "Moderate variance",
-          color: "text-yellow-400",
-          tip: "Some speed variation across demonstrators. Consider velocity normalization for best results.",
-        };
-      else
-        v = {
-          label: "High variance",
-          color: "text-red-400",
-          tip: "Large speed differences between demonstrations. Velocity normalization before training is strongly recommended.",
-        };
-
-      return {
-        speeds: sp,
-        mean: m,
-        std: s,
-        cv: c,
-        median: med,
-        bins: b,
-        lo,
-        binW: bw,
-        maxBin: Math.max(...b),
-        verdict: v,
+    let v: { label: string; color: string; tip: string };
+    if (!Number.isFinite(c))
+      // Nothing finite survived: say so instead of any confidence-coloured verdict.
+      v = {
+        label: "Not measurable",
+        color: "text-slate-400",
+        tip: "No episode has a finite speed (all values NaN/∞) — speed consistency cannot be assessed for this dataset.",
       };
-    }, [distribution]);
+    else if (c < 0.2)
+      v = {
+        label: "Consistent",
+        color: "text-green-400",
+        tip: "Demonstrators execute at similar speeds — no velocity normalization needed.",
+      };
+    else if (c < 0.4)
+      v = {
+        label: "Moderate variance",
+        color: "text-yellow-400",
+        tip: "Some speed variation across demonstrators. Consider velocity normalization for best results.",
+      };
+    else
+      v = {
+        label: "High variance",
+        color: "text-red-400",
+        tip: "Large speed differences between demonstrations. Velocity normalization before training is strongly recommended.",
+      };
 
-  if (speeds.length < 3) return null;
+    return {
+      speeds: sp,
+      dropped,
+      mean: m,
+      std: s,
+      cv: c,
+      median: med,
+      bins: b,
+      lo,
+      binW: bw,
+      maxBin: Math.max(...b),
+      verdict: v,
+    };
+  }, [distribution]);
+
+  // Hide only when there are too few episodes AT ALL; when episodes exist but their
+  // speeds are non-finite, render with the honest "Not measurable" verdict instead of
+  // silently disappearing (an absent section reads as "nothing to flag").
+  if (speeds.length < 3 && dropped === 0) return null;
 
   const barH = isFs ? 250 : 100;
   const barW = Math.max(8, Math.floor((isFs ? 900 : 500) / bins.length));
@@ -1138,7 +1168,8 @@ function SpeedVarianceSection({
           <h3 className="text-sm font-semibold text-slate-200">
             Demonstrator Speed Variance
             <span className="text-xs text-slate-500 ml-2 font-normal">
-              ({numEpisodes} episodes)
+              ({numEpisodes} episodes
+              {dropped > 0 ? `, ${dropped} excluded: non-finite speed` : ""})
             </span>
           </h3>
           <InfoToggle>

--- a/src/utils/__tests__/speedStats.test.ts
+++ b/src/utils/__tests__/speedStats.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import { episodeMovementScore, speedVarianceStats } from "../speedStats";
+
+describe("speedVarianceStats", () => {
+  test("clean input: plain stats, nothing dropped", () => {
+    const s = speedVarianceStats([0.2, 0.4, 0.3]);
+    expect(s.dropped).toBe(0);
+    expect(s.speeds).toEqual([0.2, 0.3, 0.4]);
+    expect(s.mean).toBeCloseTo(0.3, 10);
+    expect(s.median).toBeCloseTo(0.3, 10);
+    expect(s.cv).toBeGreaterThan(0);
+  });
+
+  test("NaN entries are dropped and counted — stats come from what remains", () => {
+    const s = speedVarianceStats([0.2, NaN, 0.4, NaN, 0.3]);
+    expect(s.dropped).toBe(2);
+    expect(s.speeds).toEqual([0.2, 0.3, 0.4]);
+    expect(s.mean).toBeCloseTo(0.3, 10);
+    expect(Number.isFinite(s.cv)).toBe(true);
+  });
+
+  test("THE BUG THIS EXISTS FOR: one NaN must not yield cv=0 (the false green verdict)", () => {
+    // Before: mean=NaN -> (NaN > 0) is false -> cv fell through to 0 -> "Consistent".
+    // Identical speeds except one NaN: cv must reflect the real (finite) spread, and a
+    // genuinely varied set must never come back 0 because a NaN poisoned the mean.
+    const varied = speedVarianceStats([0.1, NaN, 0.9]);
+    expect(varied.cv).toBeGreaterThan(0.2); // would have been 0 before the fix
+  });
+
+  test("Infinity is dropped like NaN — it is a broken reading, not a fast demonstrator", () => {
+    const s = speedVarianceStats([0.2, Infinity, 0.3]);
+    expect(s.dropped).toBe(1);
+    expect(s.speeds).toEqual([0.2, 0.3]);
+  });
+
+  test("nothing finite: every stat is NaN, never a fabricated 0", () => {
+    const s = speedVarianceStats([NaN, NaN]);
+    expect(s.dropped).toBe(2);
+    expect(Number.isNaN(s.mean)).toBe(true);
+    expect(Number.isNaN(s.cv)).toBe(true);
+  });
+
+  test("empty input behaves like all-dropped", () => {
+    const s = speedVarianceStats([]);
+    expect(s.speeds).toEqual([]);
+    expect(Number.isNaN(s.median)).toBe(true);
+  });
+});
+
+describe("episodeMovementScore", () => {
+  const step = (vals: number[][]) => episodeMovementScore(vals, vals[0].length);
+
+  test("clean episode matches the plain per-frame mean of ‖Δa‖", () => {
+    // Δ = (3,4) each pair -> ‖Δ‖ = 5 per pair
+    expect(
+      step([
+        [0, 0],
+        [3, 4],
+        [6, 8],
+      ]),
+    ).toBeCloseTo(5, 4);
+  });
+
+  test("a NaN dimension is excluded from that pair, not zeroed", () => {
+    // Pair 1: only dim 1 finite (Δ=4) -> 4. Pair 2 clean -> 5. Mean 4.5.
+    // Zero-substitution (the old `?? 0`) would have invented a huge Δ from the NaN dim.
+    expect(
+      step([
+        [NaN, 0],
+        [3, 4],
+        [6, 8],
+      ]),
+    ).toBeCloseTo(4.5, 4);
+  });
+
+  test("a pair with nothing finite is skipped, not averaged as zero motion", () => {
+    // Pairs touching the all-NaN frame are skipped; only (0,0)->(3,4) counts -> 5, not 5/3.
+    expect(
+      step([
+        [0, 0],
+        [NaN, NaN],
+        [0, 0],
+        [3, 4],
+      ]),
+    ).toBeCloseTo(5, 4);
+  });
+
+  test("an episode with no measurable pair returns NaN so callers can exclude it", () => {
+    expect(
+      Number.isNaN(
+        step([
+          [NaN, NaN],
+          [NaN, NaN],
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  test("short episodes keep the existing 0 contract", () => {
+    expect(episodeMovementScore([[1, 2]], 2)).toBe(0);
+    expect(episodeMovementScore([], 2)).toBe(0);
+  });
+});

--- a/src/utils/speedStats.ts
+++ b/src/utils/speedStats.ts
@@ -1,0 +1,73 @@
+/**
+ * NaN-safe statistics for the Action Insights speed sections.
+ *
+ * WHY: datasets with partial tracking (common for real-world captures — marker-based
+ * UMI rigs, mocap dropouts, SLAM losses) carry NaN in some action frames. `??` does not
+ * catch NaN, so one NaN frame made an episode's movement score NaN; one NaN score made
+ * mean/std/median NaN — and then `NaN > 0` is `false`, so the CV guard fell through to
+ * `0` and the Speed Variance verdict rendered a green "Consistent" computed from no data
+ * at all. A false pass is worse than a blank: the more NaN in the dataset, the more
+ * confidently the panel said everything was fine.
+ */
+
+export type SpeedVarianceStats = {
+  /** Finite speeds, ascending. */
+  speeds: number[];
+  /** Entries excluded because their speed was not finite (NaN/±Infinity). */
+  dropped: number;
+  mean: number;
+  std: number;
+  cv: number;
+  median: number;
+};
+
+/** Mean/std/CV/median over the FINITE entries only, reporting how many were dropped. */
+export function speedVarianceStats(raw: number[]): SpeedVarianceStats {
+  const speeds = raw.filter(Number.isFinite).sort((a, b) => a - b);
+  const dropped = raw.length - speeds.length;
+  if (speeds.length === 0) {
+    return { speeds, dropped, mean: NaN, std: NaN, cv: NaN, median: NaN };
+  }
+  const mean = speeds.reduce((a, b) => a + b, 0) / speeds.length;
+  const std = Math.sqrt(
+    speeds.reduce((a, v) => a + (v - mean) ** 2, 0) / speeds.length,
+  );
+  const cv = mean > 0 ? std / mean : 0;
+  const median = speeds[Math.floor(speeds.length / 2)];
+  return { speeds, dropped, mean, std, cv, median };
+}
+
+/**
+ * Per-episode average movement (mean ‖Δa‖ per frame) over the frame pairs and
+ * dimensions that are actually finite.
+ *
+ * A non-finite value in either frame of a pair excludes that DIMENSION from the pair's
+ * norm (a missing reading is not a zero-length motion); a pair with no finite dimension
+ * is skipped entirely. Returns NaN when nothing at all was measurable — the caller can
+ * then exclude the episode rather than average in an invented number.
+ */
+export function episodeMovementScore(
+  ep: number[][],
+  actionDim: number,
+): number {
+  if (ep.length < 2) return 0;
+  let total = 0;
+  let pairsUsed = 0;
+  for (let t = 1; t < ep.length; t++) {
+    let sumSq = 0;
+    let dimsUsed = 0;
+    for (let d = 0; d < actionDim; d++) {
+      const a = ep[t][d];
+      const b = ep[t - 1][d];
+      if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+      const delta = a - b;
+      sumSq += delta * delta;
+      dimsUsed++;
+    }
+    if (dimsUsed === 0) continue;
+    total += Math.sqrt(sumSq);
+    pairsUsed++;
+  }
+  if (pairsUsed === 0) return NaN;
+  return Math.round((total / pairsUsed) * 10000) / 10000;
+}


### PR DESCRIPTION
## The bug

Datasets with partial tracking carry `NaN` action frames — marker dropouts, SLAM losses, occlusions are all common in real-world captures. In the Action Insights panel this produced a **false-green verdict**:

1. `(ep[t][d] ?? 0)` — `??` catches `null`/`undefined` but **not** `NaN`, so one NaN frame turned the whole episode's movement score into NaN
2. one NaN score turned the Speed Variance `mean`/`std` into NaN
3. `NaN > 0` is `false` in JS, so `const c = m > 0 ? s / m : 0` fell through to `cv = 0`
4. `0 < 0.2` → **"Consistent — no velocity normalization needed"**, in green

So the more NaN a dataset has, the more confidently the panel says everything is fine. Minimal repro of step 3–4:

```js
const sp = [0.2, NaN, 0.3].sort((a, b) => a - b);
const m = sp.reduce((a, b) => a + b, 0) / sp.length;   // NaN
const c = m > 0 ? Math.sqrt(...) / m : 0;              // 0  ← NaN > 0 is false
// c < 0.2 → "Consistent" (green)
```

## Measured on a real dataset

67-episode bimanual UMI dataset with ~20–24% NaN poses per episode (marker-based tracking):

| | before | after |
|---|---|---|
| Mean / Median / Std | `NaN` / `NaN` / `NaN` | 0.0400 / 0.0386 / 0.0118 |
| CV | **0.000** | **0.296** |
| Verdict | 🟢 Consistent — no velocity normalization needed | 🟡 Moderate variance — consider velocity normalization |

The verdict flips — the panel was giving the opposite training advice.

## The fix (two layers, new `src/utils/speedStats.ts`)

**`episodeMovementScore`** — per frame pair, the norm is taken over the dimensions where **both** values are finite (a missing reading is not a zero-length motion); pairs with nothing finite are skipped; an episode where nothing at all was measurable returns `NaN` so callers can exclude it instead of averaging in an invented number.

- the low-movement ranking now excludes such episodes (unmeasured ≠ "low movement"), and its sort comparator treats NaN as `+Infinity` — the comparator was otherwise undefined behaviour on NaN
- episodes with *partial* NaN get a real speed from their finite frames, so they contribute instead of poisoning

**`speedVarianceStats`** — mean/std/CV/median over the finite entries only, with a `dropped` count the panel surfaces in the header (`(N episodes, K excluded: non-finite speed)`). When nothing finite survives, the verdict is a neutral **"Not measurable"** instead of any confidence-coloured label.

## Tests

11 new tests in `src/utils/__tests__/speedStats.test.ts`, including a pin on the exact false-green path (`[0.1, NaN, 0.9]` must not come back `cv = 0`). `bun run format` / `type-check` / `lint` / `bun test` all green (168 tests).
